### PR TITLE
Added writable file/folder verification

### DIFF
--- a/bonfire/application/core_modules/install/controllers/install.php
+++ b/bonfire/application/core_modules/install/controllers/install.php
@@ -34,6 +34,7 @@ class Install extends MX_Controller {
 		'cache',
 		'logs',
 		'config',
+        'archives',
 		'db/backups'
 	);
 	
@@ -43,7 +44,9 @@ class Install extends MX_Controller {
 		sure they can be written to.
 	*/
 	private $writeable_files = array(
-		'config/application.php'
+		'config/application.php',
+        'config/database.php',
+        'config/development/database.php'
 	);
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
Install fails due to the installer not checking all required files/folders for write permissions. This commit fixes that for config/database.php, config/development/database.php and archives/ 
