### PR TITLE
Timezone settings checked and optionally set by date_default_timezone_set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bonfire/application/logs/*
 !bonfire/application/logs/index.html
 bonfire/application/cache/*
 *.bak
+nbproject/
 
 # Testing ignoring database configuration.. it should be fine since it's already in there, but I don't know the other ramifications.
 bonfire/application/config/database.php

--- a/index.php
+++ b/index.php
@@ -46,6 +46,20 @@
 	}
 
 /*
+|---------------------------------------------------------------
+| DEFAULT INI SETTINGS
+|---------------------------------------------------------------
+|
+| Necessary settings for a higher compatibility. Inspired by PyroCMS code.
+|
+*/
+	// PHP 5.3 requires this
+	if(ini_get('date.timezone') == '')
+	{
+		date_default_timezone_set('GMT');
+	}
+
+/*
  *---------------------------------------------------------------
  * SYSTEM FOLDER NAME
  *---------------------------------------------------------------


### PR DESCRIPTION
Timezone settings checked and optionally set by date_default_timezone_set() because of PHP5.3 in index.php. If not set, it caused an error on PHP5.3. Also added Netbeans folder to .gitignore so that developers using Netbeans will not mess up the codebase.
