### PR TITLE
Update to initial table removed. It was added to the 003_permission_syste

### DIFF
--- a/bonfire/application/db/migrations/core/001_Install_initial_tables.php
+++ b/bonfire/application/db/migrations/core/001_Install_initial_tables.php
@@ -36,7 +36,6 @@ class Migration_Install_initial_tables extends Migration {
 		$this->dbforge->add_field("`Site.Content.View` tinyint(1) NOT NULL DEFAULT '0'");
 		$this->dbforge->add_field("`Site.Statistics.View` tinyint(1) NOT NULL DEFAULT '0'");
 		$this->dbforge->add_field("`Site.Appearance.View` tinyint(1) NOT NULL DEFAULT '0'");
-		$this->dbforge->add_field("`Site.Signin.Offline` tinyint(1) NOT NULL DEFAULT '0'");
 		$this->dbforge->add_field("`Site.Settings.View` tinyint(1) NOT NULL DEFAULT '0'");
 		$this->dbforge->add_field("`Site.Developer.View` tinyint(1) NOT NULL DEFAULT '0'");
 		$this->dbforge->add_field("`Bonfire.Roles.Manage` tinyint(1) NOT NULL DEFAULT '0'");


### PR DESCRIPTION
Update to initial table removed. It was added to the 003_permission_system_upgrade.
Critical: Bonfire installation fails.
