### PR TITLE
Bug fix: module_files returns array or false. 

### DIFF
--- a/bonfire/application/core_modules/migrations/controllers/developer.php
+++ b/bonfire/application/core_modules/migrations/controllers/developer.php
@@ -125,7 +125,7 @@ class Developer extends Admin_Controller {
 	
 		$modules = module_files(null, 'migrations');
 		
-		if (!count($modules))
+		if ($modules === false)
 		{
 			return false;
 		}


### PR DESCRIPTION
count() on the return value leads to an error. e.g. at  admin/developer/migrations

Plus. My `git diff` is complaining about newlines being discarded when I save.

```
-// End Migrations Developer Class
\ No newline at end of file
+// End Migrations Developer Class
```

The line feeds in some/all of the files need to be standardized. 

http://stackoverflow.com/questions/244639/git-thinks-i-am-rewriting-one-of-my-files-everytime-i-make-a-small-change
http://help.github.com/line-endings/
