### PR TITLE
Fixed logout image not showing

### DIFF
--- a/bonfire/themes/admin/index.php
+++ b/bonfire/themes/admin/index.php
@@ -44,7 +44,7 @@
 		<div id="toolbar">
 			<div id="toolbar-right">
 				<a href="<?php echo site_url('admin/settings/users/edit/'. $this->auth->user_id()) ?>" id="tb_email"><?php echo $this->auth->email() ?></a>
-				<a href="<?php echo site_url('logout') ?>" id="tb_logout" title="Logout"><img src='http://bf.localhost/bonfire/themes/admin/images/logout.png' alt='Content' /></a>
+				<a href="<?php echo site_url('logout') ?>" id="tb_logout" title="Logout"><img src='<?php echo site_url('bonfire/themes/admin/images/logout.png'); ?>' alt='Content' /></a>
 			</div>
 		
 			<h1><a href="<?php echo site_url(); ?>" target="_blank"><?php echo config_item('site.title') ?></a></h1>


### PR DESCRIPTION
The source (src) for the logout image in the admin theme was hard coded to 'http://bf.localhost/bonfire/themes/admin/images/logout.png' so I've changed it to be using the site_url function making it work whatever the address.
