### PR TITLE
Reworked Modulebuilder. List of changes.

### DIFF
--- a/bonfire/application/core_modules/modulebuilder/config/modulebuilder.php
+++ b/bonfire/application/core_modules/modulebuilder/config/modulebuilder.php
@@ -12,6 +12,13 @@ $config[ 'modulebuilder' ][ 'form_action_options' ] = array('index' => 'List',
 														'edit' => 'Edit', 
 														'delete' => 'Delete');
 
+
+/*
+ * valiation rules which will appear
+ */
+$config[ 'modulebuilder' ][ 'validation_rules' ] = array('required', 'unique', 'trim', 'xss_clean');
+$config[ 'modulebuilder' ][ 'validation_limits' ] = array('alpha', 'is_numeric', 'alpha_numeric', 'alpha_dash', 'valid_email', 'integer', 'is_decimal', 'is_natural', 'is_natural_no_zero','valid_ip','valid_base64','alpha_extra');
+														
 /*
  * default primary key field
  */

--- a/bonfire/application/core_modules/modulebuilder/controllers/developer.php
+++ b/bonfire/application/core_modules/modulebuilder/controllers/developer.php
@@ -16,8 +16,6 @@
  */
 
 class Developer extends Admin_Controller {
-	
-	public $field_numbers = array(6,10,20,40);
 
 	//---------------------------------------------------------------
 
@@ -28,8 +26,13 @@ class Developer extends Admin_Controller {
 		$this->auth->restrict('Site.Developer.View');
 		$this->load->library('modulebuilder');
 		$this->load->config('modulebuilder');
+		$this->lang->load('modulebuilder');
+		$this->load->helper('file');
+		$this->load->dbforge();
 		
 		$this->options = $this->config->item('modulebuilder');
+		
+		Assets::add_js($this->load->view('developer/modulebuilder_js', null, true), 'inline');
 	}
 
 	//---------------------------------------------------------------
@@ -39,16 +42,43 @@ class Developer extends Admin_Controller {
 	 */
 	public function index()
 	{
+		
+		$modules = module_list(true);
+		$configs = array();
+	
+		foreach ($modules as $module)
+		{
+			$configs[$module] = module_config($module);
+			
+			if (!isset($configs[$module]['name']))
+			{
+				$configs[$module]['name'] = ucwords($module);
+			}
+		}
+		
+		ksort($configs);
+		Template::set('modules', $configs);
+		Template::set('toolbar_title', 'Manage Modules');
+		Template::render();
+		
+	}
+    
+	//--------------------------------------------------------------------
+	
+	public function create()
+	{
+		$this->auth->restrict('Bonfire.Modules.Add');
+		
 		$hide_form = false;
-		$this->field_total = 6;
+		$this->field_total = $this->input->post('field_total');
+		$this->field_total = 0;
 		$last_seg = $this->uri->segment( $this->uri->total_segments() );
-
 		if (is_numeric($last_seg)) {
 			$this->field_total = $last_seg;
 		}
 		
-		if ($this->validate_form($this->field_total) == FALSE) // validation hasn't been passed
-		{
+		// validation hasn't been passed
+		if ($this->validate_form($this->field_total) == FALSE){
 			Template::set('field_total', $this->field_total);
 			
 			if (!empty($_POST))
@@ -59,12 +89,16 @@ class Developer extends Admin_Controller {
 			{
 				Template::set('form_error', FALSE);
 			}
-			
+			$query = $this->db->select('role_id,role_name')->order_by('role_name')->get('roles');
+			Template::set('roles', $query->result_array());
 			Template::set('form_action_options', $this->options['form_action_options']);
-			Template::set('field_numbers', $this->field_numbers);
-		}
-		else // passed validation proceed to second page
-		{
+			Template::set('validation_rules', $this->options['validation_rules']);
+			Template::set('validation_limits', $this->options['validation_limits']);
+			Template::set('field_numbers', range(0,20));
+			Template::set_view('developer/modulebuilder_form');
+						
+		} else {
+			// passed validation proceed to second page
 			$this->build_module($this->field_total);
 			
 			Template::set_view('developer/output');
@@ -73,6 +107,61 @@ class Developer extends Admin_Controller {
 		Template::set('error', array());
 
 		Template::set('toolbar_title', 'Module Builder');
+		
+		Template::render();
+	}
+	
+	//--------------------------------------------------------------------
+	
+	public function delete() 
+	{	
+		$module_name = $this->uri->segment(5);
+
+		if (!empty($module_name)) {	
+			$this->auth->restrict('Bonfire.Modules.Delete');
+			
+			$prefix = $this->db->dbprefix;
+			
+			$this->db->trans_begin();
+			
+			// drop the main table			
+			$this->dbforge->drop_table($module_name);
+			
+			// get any permission ids
+			$query = $this->db->query('SELECT permission_id FROM '.$prefix.'permissions WHERE name LIKE "'.$module_name.'.%.%"');
+
+			if ($query->num_rows() > 0) {
+            	foreach($query->result_array() as $row) {
+            		// undo any permissions that exist
+					$this->db->where('permission_id',$row['permission_id']);
+            		$this->db->delete($prefix.'permissions');
+					
+					// and fron the roles as well.
+					$this->db->where('permission_id',$row['permission_id']);
+					$this->db->delete($prefix.'role_permissions');            		
+            	}		
+	        }
+	        
+	        // drop the schema #
+	        $this->dbforge->drop_column('schema_version',strtolower($module_name).'_version');
+	        
+	        if ($this->db->trans_status() === FALSE) {
+				$this->db->trans_rollback();
+				Template::set_message('We could not delete this module.', $this->db->error, 'error');
+			} else {
+				$this->db->trans_commit();
+				
+				// database was successful in deleting everything. Now try to get rid of the files.
+				if (delete_files(module_path($module_name), true)) {
+					@rmdir(module_path($module_name.'/'));
+					Template::set_message('The module and associated database entries were successfully deleted.', 'success');
+					Template::redirect(SITE_AREA .'/developer/modulebuilder');
+				} else {
+					Template::set_message('The module and associated database entries were successfully deleted, HOWEVER, the module folder and files were not removed. They must be removed manually.', 'info');
+				}
+			}
+		}
+		
 		Template::render();
 	}
 
@@ -80,51 +169,64 @@ class Developer extends Admin_Controller {
 	
 	private function validate_form($field_total=0) 
 	{
-		$this->form_validation->set_rules("module_name",'Module Name',"trim|required|xss_clean");
-		$this->form_validation->set_rules("contexts",'Contexts',"required|xss_clean|is_array");
-		$this->form_validation->set_rules("form_action",'Controller Actions',"required|xss_clean|is_array");
-		$this->form_validation->set_rules("db_required",'DB Required',"trim|xss_clean|is_numeric");
-		$this->form_validation->set_rules("primary_key_field",'Primary Key Field',"required|trim|xss_clean");
-		$this->form_validation->set_rules("form_input_delimiters",'Form Input Delimiters',"required|trim|xss_clean");
+		$this->form_validation->set_rules("contexts_content",'Contexts :: Content',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("contexts_developer",'Contexts :: Developer',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("contexts_public",'Contexts :: Public',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("contexts_reports",'Contexts :: Reports',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("contexts_settings",'Contexts :: Settings',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("db_required",'Generate Migration',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("form_action_create",'Form Actions :: View',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("form_action_delete",'Form Actions :: View',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("form_action_edit",'Form Actions :: View',"trim|xss_clean|is_numeric");
+		$this->form_validation->set_rules("form_action_view",'Form Actions :: List',"trim|xss_clean|is_numeric");
 		$this->form_validation->set_rules("form_error_delimiters",'Form Error Delimiters',"required|trim|xss_clean");
-		$this->form_validation->set_rules("textarea_editor",'Textarea Editor',"trim|xss_clean");
+		$this->form_validation->set_rules("form_input_delimiters",'Form Input Delimiters',"required|trim|xss_clean");
+		$this->form_validation->set_rules("module_description",'Module Description',"trim|required|xss_clean");
+		$this->form_validation->set_rules("module_name",'Module Name',"trim|required|xss_clean|alpha_dash");
+		$this->form_validation->set_rules("role_id",'Give Role Full Access',"trim|xss_clean|is_numeric");
 		
-		for($counter=1; $field_total >= $counter; $counter++)
-		{
-			if ($counter != 1) // better to do it this way round as this statement will be fullfilled more than the one below
+		// no point doing all this checking if we don't want a table
+		if ($this->input->post('db_required')) {
+			$this->form_validation->set_rules("primary_key_field",'Primary Key Field',"required|trim|xss_clean|alpha_dash");
+			$this->form_validation->set_rules("table_name",'Table Name',"trim|required|xss_clean|alpha_dash");
+			$this->form_validation->set_rules("textarea_editor",'Textarea Editor',"trim|xss_clean|alpha_dash");
+		
+			for($counter=1; $field_total >= $counter; $counter++)
 			{
-				$this->form_validation->set_rules("view_field_label$counter","Label $counter",'trim|xss_clean');
+				if ($counter != 1) // better to do it this way round as this statement will be fullfilled more than the one below
+				{
+					$this->form_validation->set_rules("view_field_label$counter","Label $counter",'trim|xss_clean|alpha_dash');
+				}
+				else
+				{
+					// the first field always needs to be required i.e. we need to have at least one field in our form
+					$this->form_validation->set_rules("view_field_label$counter","Label $counter",'trim|required|xss_clean|alpha_dash');
+				}
+				
+				$name_required = '';
+				$label = $this->input->post("view_field_label$counter");
+				if( !empty($label) )
+				{
+					$name_required = 'required|';
+				}
+				$this->form_validation->set_rules("view_field_name$counter","Name $counter","trim|".$name_required."callback_no_match[$counter]|xss_clean");
+				$this->form_validation->set_rules("view_field_type$counter","Field Type $counter","trim|required|xss_clean|alpha");
+				$this->form_validation->set_rules("db_field_type$counter","DB Field Type $counter","trim|xss_clean|alpha");
+				
+				// make sure that the length field is required if the DB Field type requires a length
+				$db_len_required = '';
+				$field_type = $this->input->post("db_field_type$counter");
+				if( !empty($label) && !($field_type == 'TEXT' 
+					OR $field_type == 'DATE' OR $field_type == 'TIME' OR $field_type == 'DATETIME'
+					OR $field_type == 'TIMESTAMP' OR $field_type == 'YEAR'
+					 OR $field_type == 'TINYBLOB' OR $field_type == 'BLOB' OR $field_type == 'MEDIUMBLOB' OR $field_type == 'LONGBLOB') )
+				{
+					$db_len_required = 'required|';
+				}
+				$this->form_validation->set_rules("db_field_length_value$counter","DB Field Length $counter","trim|".$db_len_required."xss_clean");
+				$this->form_validation->set_rules('validation_rules'.$counter.'[]',"Validation Rules $counter",'trim|xss_clean');
 			}
-			else
-			{
-				// the first field always needs to be required i.e. we need to have at least one field in our form
-				$this->form_validation->set_rules("view_field_label$counter","Label $counter",'trim|required|xss_clean');
-			}
-			
-			$name_required = '';
-			$label = $this->input->post("view_field_label$counter");
-			if( !empty($label) )
-			{
-				$name_required = 'required|';
-			}
-			$this->form_validation->set_rules("view_field_name$counter","Name $counter","trim|".$name_required."callback_no_match[$counter]|xss_clean");
-			$this->form_validation->set_rules("view_field_type$counter","Field Type $counter","trim|required|xss_clean");
-			$this->form_validation->set_rules("db_field_type$counter","DB Field Type $counter","trim|xss_clean");
-			
-			// make sure that the length field is required if the DB Field type requires a length
-			$db_len_required = '';
-			$field_type = $this->input->post("db_field_type$counter");
-			if( !empty($label) && !($field_type == 'TEXT' 
-				OR $field_type == 'DATE' OR $field_type == 'TIME' OR $field_type == 'DATETIME'
-				OR $field_type == 'TIMESTAMP' OR $field_type == 'YEAR'
-				 OR $field_type == 'TINYBLOB' OR $field_type == 'BLOB' OR $field_type == 'MEDIUMBLOB' OR $field_type == 'LONGBLOB') )
-			{
-				$db_len_required = 'required|';
-			}
-			$this->form_validation->set_rules("db_field_length_value$counter","DB Field Length $counter","trim|".$db_len_required."xss_clean");
-			$this->form_validation->set_rules('validation_rules'.$counter.'[]',"Validation Rules $counter",'trim|xss_clean');
 		}
-		
 		return $this->form_validation->run();
 	}
 	
@@ -132,15 +234,20 @@ class Developer extends Admin_Controller {
 	
 	private function build_module($field_total=0) 
 	{
-		$module_name = $this->input->post('module_name');
-		$contexts = $this->input->post('contexts');
-		$action_names = $this->input->post('form_action');
+		$module_name 		= $this->input->post('module_name');
+		$table_name 		= str_replace(' ','_',strtolower($this->input->post('table_name')));
+		$contexts 			= $this->input->post('contexts');
+		$action_names 		= $this->input->post('form_action');
+		$module_description = $this->input->post('module_description');
+		$role_id			= $this->input->post('role_id');
 		
 		$db_required = isset($_POST['db_required']) ? TRUE : FALSE;
+		
 		$primary_key_field = $this->input->post('primary_key_field');
 		if( $primary_key_field == '') {
 			$primary_key_field = $this->options['primary_key_field'];
 		}
+		$primary_key_field = strtolower($primary_key_field);
 		
 		$form_input_delimiters = explode(',', $this->input->post('form_input_delimiters'));
 		
@@ -153,12 +260,13 @@ class Developer extends Admin_Controller {
 			$form_error_delimiters = $this->options['$form_error_delimiters'];
 		}
 		
-		$file_data = $this->modulebuilder->build_files($field_total, $module_name, $contexts, $action_names, $primary_key_field, $db_required, $form_input_delimiters, $form_error_delimiters);
+		$file_data = $this->modulebuilder->build_files($field_total, $module_name, $contexts, $action_names, $primary_key_field, $db_required, $form_input_delimiters, $form_error_delimiters, $module_description, $role_id, $table_name);
 
 		// make the variables available to the view file
 		$data['module_name']		= $module_name;
 		$data['module_name_lower']	= strtolower($module_name);
-		$data['controller_name']	=  $module_name;
+		$data['controller_name']	= $module_name;
+		$data['table_name']			= empty($table_name) ? $module_name : $table_name;
 		$data = $data + $file_data;
 		
 		Template::set($data);

--- a/bonfire/application/core_modules/modulebuilder/language/english/modulebuilder_lang.php
+++ b/bonfire/application/core_modules/modulebuilder/language/english/modulebuilder_lang.php
@@ -1,0 +1,113 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+	Copyright (c) 2011 Lonnie Ezell
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+	
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+	
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+// INDEX page
+$lang['mb_actions']				= 'Actions';
+$lang['mb_create_button']		= 'Create Module';
+$lang['mb_create_note']			= 'Use our wizbang module building wizard to create your next module. We do all the heavy lifting by generating all the controllers, models, views and language files you need.';
+$lang['mb_delete']				= 'Delete';
+$lang['mb_generic_description']	= 'Your Description here.';
+$lang['mb_installed_head']		= 'Installed Application Modules';
+$lang['mb_module']				= 'Module';
+$lang['mb_no_modules']			= 'No Modules Installed.';
+
+$lang['mb_table_name']			= 'Name';
+$lang['mb_table_version']		= 'Version';
+$lang['mb_table_author']		= 'Author';
+$lang['mb_table_description']	= 'Description';
+
+// OUTPUT page
+$lang['mb_out_success']	= 'The module creation was successful! Below you will find the list of Controller, Model, Language, Migration and View files that were created during this process. Model and SQL files will be included if you selected the "Generate Migration" option and a Javascript file if it was required during creation.';
+$lang['mb_out_success_note']	= 'NOTE: Please add extra user input validation as you require.  This code is to be used as a starting point only.';
+$lang['mb_out_tables'] 			= 'The database tables are <strong>NOT</strong> automatically installed for you. You still need to go to the %s section and migrate your database table(s) before you can work with them.';
+$lang['mb_out_acl'] 			= 'Access Control File';
+$lang['mb_out_acl_path']        = 'migrations/001_Install_%s_permissions.php';
+$lang['mb_out_config'] 			= 'Config file';
+$lang['mb_out_config_path'] 	= 'config/config.php';
+$lang['mb_out_controller']		= 'Controllers';
+$lang['mb_out_controller_path']	= 'controllers/%s.php';
+$lang['mb_out_model'] 			= 'Models';
+$lang['mb_out_model_path']		= '%s_model.php';
+$lang['mb_out_view']			= 'Views';
+$lang['mb_out_view_path']		= 'views/%s.php';
+$lang['mb_out_lang']			= 'Language File';
+$lang['mb_out_lang_path']		= '%s_lang.php';
+$lang['mb_out_migration']		= 'Migration File(s)';
+$lang['mb_out_migration_path']	= 'migrations/002_Install_%s.php';
+
+// FORM page
+$lang['mb_form_note'] = '<p><b>Fill out the fields you would like in your module (an "id" field is created automatically).  If you want to create the SQL for a DB table check the "Create Module Table" box.</b></p><p>This form will generate a full CodeIgniter module (model, controller and views) and, if you choose, database Migration file(s).</p>';
+
+$lang['mb_table_note'] = '<p>Your table will be created with at least one field, the primary key field that will be used as a unique identifier and as an index. If you required additional fields, click the number you require to add them to this form.</p>';
+
+$lang['mb_field_note'] = '<p><b>NOTE : FOR ALL FIELDS</b><br />If DB field type is "enum" or "set", please enter the values using this format: \'a\',\'b\',\'c\'...<br />If you ever need to put a backslash ("\") or a single quote ("\'") amongst those values, precede it with a backslash (for example \'\\xyz\' or \'a\\\'b\').</p>';
+	
+$lang['mb_form_errors']			= 'Please correct the errors below.';
+$lang['mb_form_mod_details']	= 'Module Details ';
+$lang['mb_form_mod_name']		= 'Module Name';
+$lang['mb_form_mod_name_ph']	= 'Forums, Blog, ToDo';
+$lang['mb_form_mod_desc']		= 'Module Description';
+$lang['mb_form_mod_desc_ph']	= 'A list of todo items';
+$lang['mb_form_contexts']		= 'Contexts Required';
+$lang['mb_form_public']			= 'Public';
+$lang['mb_form_table_details']	= 'Table Details';
+$lang['mb_form_actions']		= 'Controller Actions';
+$lang['mb_form_primarykey']		= 'Primary Key';
+$lang['mb_form_delims']			= 'Form Input Delimiters';
+$lang['mb_form_err_delims']		= 'Form Error Delimiters';
+$lang['mb_form_text_ed']		= 'Textarea Editor';
+$lang['mb_form_generate']		= 'Create Module Table';
+$lang['mb_form_role_id']		= 'Give Role Full Access';
+$lang['mb_form_fieldnum']		= 'Additional table fields';
+$lang['mb_form_field_details']	= 'Field details';
+$lang['mb_form_table_name']		= 'Table Name';
+$lang['mb_form_table_name_ph']	= 'Lowercase, no spaces';
+$lang['mb_form_label']			= 'Label';
+$lang['mb_form_label_ph']		= 'The name that will be used on webpages';
+$lang['mb_form_fieldname']		= 'Name (no spaces)';
+$lang['mb_form_fieldname_ph']	= 'The field name for the database. Lowercase is best.';
+$lang['mb_form_type']			= 'Webpage Input Type';
+$lang['mb_form_length']			= 'Maximum Length <b>-or-</b> Values';
+$lang['mb_form_length_ph']		= '30, 255, 1000, etc...';
+$lang['mb_form_dbtype']			= 'Database Type';
+$lang['mb_form_rules']			= 'Validation Rules';
+$lang['mb_form_rules_limits']	= 'Input Limitations'; 
+$lang['mb_form_required']		= 'Required';
+$lang['mb_form_unique']			= 'Unique';
+$lang['mb_form_trim']			= 'Trim';
+$lang['mb_form_xss_clean']		= 'Sanitize';
+$lang['mb_form_valid_email']	= 'Valid Email';
+$lang['mb_form_is_numeric']		= '0-9';
+$lang['mb_form_alpha']			= 'a-Z';
+$lang['mb_form_alpha_dash']		= 'a-Z, 0-9, and _-';
+$lang['mb_form_alpha_numeric']	= 'a-Z and 0-9';
+$lang['mb_form_add_fld_button'] = 'Add another field';
+$lang['mb_form_show_advanced']	= '(Toggle Advanced Options)';
+$lang['mb_form_show_more']		= '...toggle more rules...';
+$lang['mb_form_integer']		= 'Integers';
+$lang['mb_form_is_decimal']		= 'Decimal Numbers';
+$lang['mb_form_is_natural']		= 'Natural Numbers';
+$lang['mb_form_is_natural_no_zero']	= 'Natural, no zeroes';
+$lang['mb_form_valid_ip']		= 'Valid IP';
+$lang['mb_form_valid_base64']	= 'Valid Base64';
+$lang['mb_form_alpha_extra']	= 'AlphaNumerics, underscore, dash, periods and spaces.';

--- a/bonfire/application/core_modules/modulebuilder/views/developer/index.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/index.php
@@ -1,225 +1,75 @@
-
-<?php
-	$cur_url = uri_string();
-	$tot = $this->uri->total_segments();
-	$last_seg = $this->uri->segment( $tot);
-
-	if( is_numeric($last_seg) ) {
-		$cur_url = str_replace('/index/'.$last_seg, '', $cur_url);
-	}
-?>
-
-<div class="notification information">
-	<p><b>Fill out the fields you would like in your module (an "id" field is created automatically).  If you want to create the SQL for a DB table check "DB Required".</b></p>
+<div class="view split-view">
 	
-	<p>This form will generate a full CodeIgniter module (model, controller and views) and if you choose DB Migrations files.</p>
+	<!-- Role List -->
+	<div class="view">	
+	<?php if (isset($modules) && is_array($modules) && count($modules)) : ?>
+		<div class="scrollable">
+			<div class="list-view" id="module-list">
+				<?php foreach ($modules as $module => $config) : ?>
+					<div class="list-item with-icon" data-id="<?php echo $config['name'] ?>">
+						<img src="<?php echo Template::theme_url('images/database.png') ?>" />
+					
+						<p>
+							<b><?php echo $config['name'] ?></b><br/>
+							<span class="small"><?php echo isset($config['description']) ? $config['description'] : lang('mb_generic_description'); ?></span>
+						</p>
+					</div>
+				<?php endforeach; ?>
+			</div>	<!-- /list-view -->
+		</div>
 	
-	<p>If DB field type is "enum" or "set", please enter the values using this format: 'a','b','c'...
-	<br />If you ever need to put a backslash ("\") or a single quote ("'") amongst those values, precede it with a backslash (for example '\\xyz' or 'a\'b').
-	</p>
+	<?php else: ?>
+	
+		<div class="notification attention">
+			<p><?php echo lang('mb_no_modules'); ?></p>
+		</div>
+	
+	<?php endif; ?>
+	</div>
+	
+	<!-- Role Editor -->
+	<div id="content" class="view">
+		<div class="scrollable" id="ajax-content">
+				
+				<div class="box create rounded">
+					<a class="button good" href="<?php echo site_url(SITE_AREA .'/developer/modulebuilder/create'); ?>"><?php echo lang('mb_create_button'); ?></a>
+				
+					<h3><?php echo ucwords(lang('mb_create_button')); ?></h3>
+					
+					<p><?php echo lang('mb_create_note'); ?></p>
+				</div>	
+				
+				
+				<br/>
+
+				<?php if (isset($modules) && is_array($modules) && count($modules)) : ?>
+				
+					<h2><?php echo lang('mb_installed_head'); ?></h2>
+				
+					<table>
+						<thead>
+							<tr>
+								<th><?php echo lang('mb_table_name'); ?></th>
+								<th><?php echo lang('mb_table_version'); ?></th>
+								<th><?php echo lang('mb_table_description'); ?></th>
+								<th><?php echo lang('mb_table_author'); ?></th>
+								<th><?php echo lang('mb_actions'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+						<?php foreach ($modules as $module => $config) : ?>
+							<tr>
+								<td><?php echo $config['name'] ?></td>
+								<td><?php echo isset($config['version']) ? $config['version'] : '---'; ?></td>
+								<td><?php echo isset($config['description']) ? $config['description'] : '---'; ?></td>
+								<td><?php echo isset($config['author']) ? $config['author'] : '---'; ?></td>
+								<td><?php echo anchor(SITE_AREA .'/developer/modulebuilder/delete/'. $config['name'], lang('mb_delete'),'class="confirm_delete" title="'.$config['name'].'"') ?></td>
+							</tr>
+						<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endif; ?>
+				
+		</div>	<!-- /ajax-content -->
+	</div>	<!-- /content -->
 </div>
-
-<?php if ($this->session->flashdata('error')): ?>
-<div class="top_error"><?php echo $this->session->flashdata('error')?></div>
-<?php endif; ?>
-<?php if (validation_errors()) : ?>
-<div class="notification error">
-<?php echo validation_errors();  ?>
-</div>
-<?php endif; ?>
-<?php if ($form_error): ?>
-<div class="important">
-<h4>Please correct the errors below.</h4>
-</div>
-<?php endif; ?>
-
-
-<?php echo form_open($cur_url."/index/".$field_total."/", 'class="constrained"'); ?>
-<div>  
-	<!-- Module Details -->
-	<fieldset style="margin-top: 0">
-		<legend>Module details</legend>
-		<?php echo form_error("module_name"); ?>
-		<?php echo form_error("form_input_delimiters"); ?>
-		<?php echo form_error("form_error_delimiters"); ?>
-		<div>
-			<label for="module_name" class="block">Module Name</label>
-			<input name="module_name" id="module_name" type="text" value="<?php echo set_value("module_name"); ?>" />
-		</div>
-
-		<div>
-			<label for="contexts" class="block">Contexts Required</label>
-			
-			<input name="contexts[]" type="checkbox" value="public" <?php echo set_checkbox("contexts", 'public', true); ?> /> Public
-			<?php foreach (config_item('contexts') as $context) : ?>
-				<input name="contexts[]" type="checkbox" value="<?php echo $context ?>" <?php echo set_checkbox("contexts", $context, true); ?> /> <?php echo ucwords($context) ?>
-			<?php endforeach; ?>
-		</div>
-		<div>
-		<?php echo form_error("form_action"); ?>
-			<label for="form_action">Controller Actions</label>
-
-			<?php foreach($form_action_options as $value => $label): ?>
-			<?php 
-			$data = array(
-				'name'        => 'form_action[]',
-				'id'          => 'form_action',
-				'value'       => $value,
-				'checked'     => set_checkbox('form_action', $value, true),
-				);
-
-			echo form_checkbox($data); ?> <?php echo $label;?>
-			<?php endforeach;?>
-		</div>
-		<br />
-		<div>
-			<label for="primary_key_field" class="block">Primary Key</label>
-			<input name="primary_key_field" id="primary_key_field" type="text" value="<?php echo set_value("primary_key_field", 'id'); ?>" />
-		</div>
-		<div>
-			<label for="form_input_delimiters" class="block">Form Input Delimiters</label>
-			<input name="form_input_delimiters" id="form_input_delimiters" type="text" value="<?php echo set_value("form_input_delimiters", '<div>,</div>'); ?>" />
-		</div>
-		<div>
-			<label for="form_error_delimiters" class="block">Form Error Delimiters</label>
-			<input name="form_error_delimiters" id="form_error_delimiters" type="text" value="<?php echo set_value("form_error_delimiters", "<span class='error'>,</span>"); ?>" />
-		</div>
-		<div>
-			<label for="textarea_editor" class="block">Textarea Editor</label>
-			<?php 
-				$textarea_editors = array('' => 'None', 'ckeditor' => 'CKEditor', 'xinha' => 'Xinha');
-			?>
-			<?php echo form_dropdown("textarea_editor", $textarea_editors, set_value("textarea_editor")); ?>
-		</div>
-
-		<div>
-			<label for="db_required">Generate Migration</label>
-			<input name="db_required" id="db_required" type="checkbox" value="1" <?php echo set_checkbox("db_required", "1", true); ?> class="checkbox" />
-		</div>
-
-	</fieldset>
-		<div>
-
-		Number of fields 
-		<?php 
-		$field_num_count = count($field_numbers);
-		for($ndx=0; $ndx < $field_num_count; $ndx++): ?>
-		<a href="<?php echo site_url($cur_url."/index/{$field_numbers[$ndx]}"); ?>" <?php if ($field_numbers[$ndx] == $field_total) { echo 'class="current"'; } ?>><?php echo $field_numbers[$ndx]; ?></a><?php echo $ndx < $field_num_count - 1 ? ' | ' : '';?>
-		<?php endfor; ?>
-
-		</div>
-</div>
-
-		<?php
-for ($count = 1; $count <= $field_total; $count++) // loop to build 10 form boxes
-{
-?>
-
-<div class="container <?php if ($count % 2): ?>left<?php endif;?>">  
-	<fieldset>
-		<legend>Field details <?php echo $count; ?></legend>
-
-		<?php echo form_error("view_field_label{$count}"); ?>
-		<?php echo form_error("view_field_name{$count}"); ?>
-		<?php echo form_error("view_field_type{$count}"); ?>
-
-		<div>
-
-		<label for="view_field_label<?php echo $count; ?>">Label</label>
-
-		<input name="view_field_label<?php echo $count; ?>" id="view_field_label<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_label{$count}"); ?>" onkeyup="liveUrlTitle(<?php echo $count; ?>);" />
-		</div>
-
-		<div>
-		<label for="view_field_name">Name (no spaces)</label>
-		<input name="view_field_name<?php echo $count; ?>" id="view_field_name<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_name{$count}"); ?>" maxlength="30" />
-		</div>
-
-		<div>
-		<label for="view_field_type<?php echo $count; ?>">Type</label>
-
-		<?php
-		$view_field_types = array(
-								'input' 	=> 'INPUT',
-								'textarea' 	=> 'TEXTAREA',
-								'select' 	=> 'SELECT',
-								'radio' 	=> 'RADIO',
-								'checkbox' 	=> 'CHECKBOX',
-								'password' 	=> 'PASSWORD'
-								);
-		?>
-		<?php echo form_dropdown("view_field_type{$count}", $view_field_types, set_value("view_field_type{$count}")); ?>
-		</div>
-
-		<div>
-		<label for="db_field_length_value<?php echo $count; ?>">Length/Values</label>
-		<input name="db_field_length_value<?php echo $count; ?>" type="text" value="<?php echo set_value("db_field_length_value{$count}"); ?>" />
-		</div>
-
-		<?php echo form_error("db_field_type{$count}"); ?>
-		<?php echo form_error("db_field_length_value{$count}"); ?>
-
-		<div>
-		<label for="db_field_type<?php echo $count; ?>">Database Type</label>
-
-		<?php
-		$db_field_types = array(
-								'VARCHAR' 		=> 'VARCHAR',
-								'TINYINT' 		=> 'TINYINT',
-								'TEXT' 			=> 'TEXT',
-								'DATE' 			=> 'DATE',
-								'SMALLINT' 		=> 'SMALLINT',
-								'MEDIUMINT' 	=> 'MEDIUMINT',
-								'INT' 			=> 'INT',
-								'BIGINT' 		=> 'BIGINT',
-								'FLOAT' 		=> 'FLOAT',
-								'DOUBLE' 		=> 'DOUBLE',
-								'DECIMAL' 		=> 'DECIMAL',
-								'DATETIME' 		=> 'DATETIME',
-								'TIMESTAMP' 	=> 'TIMESTAMP',
-								'TIME' 			=> 'TIME',
-								'YEAR' 			=> 'YEAR',
-								'CHAR' 			=> 'CHAR',
-								'TINYBLOB' 		=> 'TINYBLOB',
-								'TINYTEXT' 		=> 'TINYTEXT',
-								'BLOB' 			=> 'BLOB',
-								'MEDIUMBLOB' 	=> 'MEDIUMBLOB',
-								'MEDIUMTEXT' 	=> 'MEDIUMTEXT',
-								'LONGBLOB' 		=> 'LONGBLOB',
-								'LONGTEXT' 		=> 'LONGTEXT',
-								'ENUM' 			=> 'ENUM',
-								'SET' 			=> 'SET',
-								'BIT' 			=> 'BIT',
-								'BOOL' 			=> 'BOOL',
-								'BINARY' 		=> 'BINARY',
-								'VARBINARY' 	=> 'VARBINARY'
-								);
-		?>
-		<?php echo form_dropdown("db_field_type{$count}", $db_field_types, set_value("db_field_type{$count}")); ?>
-
-		</div>
-
-		<label for="db_field_length_value<?php echo $count; ?>">Validation Rules</label>
-
-		<?php echo form_error('cont_validation_rules'.$count.'[]'); ?>
-
-		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="required" <?php echo set_checkbox('validation_rules'.$count.'[]', 'required'); ?>  /> required
-
-		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="trim" <?php echo set_checkbox('validation_rules'.$count.'[]', 'trim'); ?> /> trim
-
-		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="xss_clean" <?php echo set_checkbox('validation_rules'.$count.'[]', 'xss_clean'); ?> /> xss_clean
-
-		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="valid_email" <?php echo set_checkbox('validation_rules'.$count.'[]', 'valid_email'); ?> /> valid_email
-
-		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="is_numeric" <?php echo set_checkbox('validation_rules'.$count.'[]', 'is_numeric'); ?> /> is_numeric
-	</fieldset>
-</div><!-- end container -->
-<?php
-} // end loop
-?>
-
-<div class="submits">
-	<br />
-	<?php echo form_submit('submit', 'Build the Module'); ?>
-</div>
-<?php echo form_close()?>

--- a/bonfire/application/core_modules/modulebuilder/views/developer/index_old.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/index_old.php
@@ -1,0 +1,232 @@
+
+<?php
+	$cur_url = uri_string();
+	$tot = $this->uri->total_segments();
+	$last_seg = $this->uri->segment( $tot);
+
+	if( is_numeric($last_seg) ) {
+		$cur_url = str_replace('/index/'.$last_seg, '', $cur_url);
+	}
+?>
+
+<div class="notification information">
+	<p><b>Fill out the fields you would like in your module (an "id" field is created automatically).  If you want to create the SQL for a DB table check the "Generate Migration" box.</b></p>
+	
+	<p>This form will generate a full CodeIgniter module (model, controller and views) and, if you choose, database Migrations file.</p>
+	
+	<p>If DB field type is "enum" or "set", please enter the values using this format: 'a','b','c'...
+	<br />If you ever need to put a backslash ("\") or a single quote ("'") amongst those values, precede it with a backslash (for example '\\xyz' or 'a\'b').
+	</p>
+	
+	<p>You can also generate a generic meta table based on this table's name. It will consist of 4 fields : id, link_id, property, value</p>
+</div>
+
+<?php if ($this->session->flashdata('error')): ?>
+<div class="top_error"><?php echo $this->session->flashdata('error')?></div>
+<?php endif; ?>
+<?php if (validation_errors()) : ?>
+<div class="notification error">
+<?php echo validation_errors();  ?>
+</div>
+<?php endif; ?>
+<?php if ($form_error): ?>
+<div class="important">
+<h4>Please correct the errors below.</h4>
+</div>
+<?php endif; ?>
+
+
+<?php echo form_open($cur_url."/index/".$field_total."/", 'class="constrained"'); ?>
+<div>  
+	<!-- Module Details -->
+	<fieldset style="margin-top: 0">
+		<legend>Module details</legend>
+		<?php echo form_error("module_name"); ?>
+		<?php echo form_error("form_input_delimiters"); ?>
+		<?php echo form_error("form_error_delimiters"); ?>
+		<div>
+			<label for="module_name" class="block">Module Name</label>
+			<input name="module_name" id="module_name" type="text" value="<?php echo set_value("module_name"); ?>" />
+		</div>
+
+		<div>
+			<label for="contexts" class="block">Contexts Required</label>
+			
+			<input name="contexts[]" type="checkbox" value="public" <?php echo set_checkbox("contexts", 'public', true); ?> /> Public
+			<?php foreach (config_item('contexts') as $context) : ?>
+				<input name="contexts[]" type="checkbox" value="<?php echo $context ?>" <?php echo set_checkbox("contexts", $context, true); ?> /> <?php echo ucwords($context) ?>
+			<?php endforeach; ?>
+		</div>
+		<div>
+		<?php echo form_error("form_action"); ?>
+			<label for="form_action">Controller Actions</label>
+
+			<?php foreach($form_action_options as $value => $label): ?>
+			<?php 
+			$data = array(
+				'name'        => 'form_action[]',
+				'id'          => 'form_action',
+				'value'       => $value,
+				'checked'     => set_checkbox('form_action', $value, true),
+				);
+
+			echo form_checkbox($data); ?> <?php echo $label;?>
+			<?php endforeach;?>
+		</div>
+		<br />
+		<div>
+			<label for="primary_key_field" class="block">Primary Key</label>
+			<input name="primary_key_field" id="primary_key_field" type="text" value="<?php echo set_value("primary_key_field", 'id'); ?>" />
+		</div>
+		<div>
+			<label for="form_input_delimiters" class="block">Form Input Delimiters</label>
+			<input name="form_input_delimiters" id="form_input_delimiters" type="text" value="<?php echo set_value("form_input_delimiters", '<div>,</div>'); ?>" />
+		</div>
+		<div>
+			<label for="form_error_delimiters" class="block">Form Error Delimiters</label>
+			<input name="form_error_delimiters" id="form_error_delimiters" type="text" value="<?php echo set_value("form_error_delimiters", "<span class='error'>,</span>"); ?>" />
+		</div>
+		<div>
+			<label for="textarea_editor" class="block">Textarea Editor</label>
+			<?php 
+				$textarea_editors = array('' => 'None', 'ckeditor' => 'CKEditor', 'xinha' => 'Xinha');
+			?>
+			<?php echo form_dropdown("textarea_editor", $textarea_editors, set_value("textarea_editor")); ?>
+		</div>
+
+		<div>
+			<label for="db_required">Generate Migration</label>
+			<input name="db_required" id="db_required" type="checkbox" value="1" <?php echo set_checkbox("db_required", "1", true); ?> class="checkbox" />
+		</div>
+
+		<div>
+			<label for="meta_required">Create meta table also?</label>
+			<input name="meta_required" id="meta_required" type="checkbox" value="1" <?php echo set_checkbox("meta_required", "1", true); ?> class="checkbox" />
+		</div>
+
+	</fieldset>
+		<div>
+
+		Number of fields 
+		<?php 
+		$field_num_count = count($field_numbers);
+		for($ndx=0; $ndx < $field_num_count; $ndx++): ?>
+		<a href="<?php echo site_url($cur_url."/index/{$field_numbers[$ndx]}"); ?>" <?php if ($field_numbers[$ndx] == $field_total) { echo 'class="current"'; } ?>><?php echo $field_numbers[$ndx]; ?></a><?php echo $ndx < $field_num_count - 1 ? ' | ' : '';?>
+		<?php endfor; ?>
+
+		</div>
+</div>
+
+		<?php
+for ($count = 1; $count <= $field_total; $count++) // loop to build 10 form boxes
+{
+?>
+
+<div class="container <?php if ($count % 2): ?>left<?php endif;?>">  
+	<fieldset>
+		<legend>Field details <?php echo $count; ?></legend>
+
+		<?php echo form_error("view_field_label{$count}"); ?>
+		<?php echo form_error("view_field_name{$count}"); ?>
+		<?php echo form_error("view_field_type{$count}"); ?>
+
+		<div>
+
+		<label for="view_field_label<?php echo $count; ?>">Label</label>
+
+		<input name="view_field_label<?php echo $count; ?>" id="view_field_label<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_label{$count}"); ?>" onkeyup="liveUrlTitle(<?php echo $count; ?>);" />
+		</div>
+
+		<div>
+		<label for="view_field_name">Name (no spaces)</label>
+		<input name="view_field_name<?php echo $count; ?>" id="view_field_name<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_name{$count}"); ?>" maxlength="30" />
+		</div>
+
+		<div>
+		<label for="view_field_type<?php echo $count; ?>">Type</label>
+
+		<?php
+		$view_field_types = array(
+								'input' 	=> 'INPUT',
+								'textarea' 	=> 'TEXTAREA',
+								'select' 	=> 'SELECT',
+								'radio' 	=> 'RADIO',
+								'checkbox' 	=> 'CHECKBOX',
+								'password' 	=> 'PASSWORD'
+								);
+		?>
+		<?php echo form_dropdown("view_field_type{$count}", $view_field_types, set_value("view_field_type{$count}")); ?>
+		</div>
+
+		<div>
+		<label for="db_field_length_value<?php echo $count; ?>">Length/Values</label>
+		<input name="db_field_length_value<?php echo $count; ?>" type="text" value="<?php echo set_value("db_field_length_value{$count}"); ?>" />
+		</div>
+
+		<?php echo form_error("db_field_type{$count}"); ?>
+		<?php echo form_error("db_field_length_value{$count}"); ?>
+
+		<div>
+		<label for="db_field_type<?php echo $count; ?>">Database Type</label>
+
+		<?php
+		$db_field_types = array(
+								'VARCHAR' 		=> 'VARCHAR',
+								'TINYINT' 		=> 'TINYINT',
+								'TEXT' 			=> 'TEXT',
+								'DATE' 			=> 'DATE',
+								'SMALLINT' 		=> 'SMALLINT',
+								'MEDIUMINT' 	=> 'MEDIUMINT',
+								'INT' 			=> 'INT',
+								'BIGINT' 		=> 'BIGINT',
+								'FLOAT' 		=> 'FLOAT',
+								'DOUBLE' 		=> 'DOUBLE',
+								'DECIMAL' 		=> 'DECIMAL',
+								'DATETIME' 		=> 'DATETIME',
+								'TIMESTAMP' 	=> 'TIMESTAMP',
+								'TIME' 			=> 'TIME',
+								'YEAR' 			=> 'YEAR',
+								'CHAR' 			=> 'CHAR',
+								'TINYBLOB' 		=> 'TINYBLOB',
+								'TINYTEXT' 		=> 'TINYTEXT',
+								'BLOB' 			=> 'BLOB',
+								'MEDIUMBLOB' 	=> 'MEDIUMBLOB',
+								'MEDIUMTEXT' 	=> 'MEDIUMTEXT',
+								'LONGBLOB' 		=> 'LONGBLOB',
+								'LONGTEXT' 		=> 'LONGTEXT',
+								'ENUM' 			=> 'ENUM',
+								'SET' 			=> 'SET',
+								'BIT' 			=> 'BIT',
+								'BOOL' 			=> 'BOOL',
+								'BINARY' 		=> 'BINARY',
+								'VARBINARY' 	=> 'VARBINARY'
+								);
+		?>
+		<?php echo form_dropdown("db_field_type{$count}", $db_field_types, set_value("db_field_type{$count}")); ?>
+
+		</div>
+
+		<label for="db_field_length_value<?php echo $count; ?>">Validation Rules</label>
+
+		<?php echo form_error('cont_validation_rules'.$count.'[]'); ?>
+
+		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="required" <?php echo set_checkbox('validation_rules'.$count.'[]', 'required'); ?>  /> required
+
+		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="trim" <?php echo set_checkbox('validation_rules'.$count.'[]', 'trim'); ?> /> trim
+
+		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="xss_clean" <?php echo set_checkbox('validation_rules'.$count.'[]', 'xss_clean'); ?> /> xss_clean
+
+		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="valid_email" <?php echo set_checkbox('validation_rules'.$count.'[]', 'valid_email'); ?> /> valid_email
+
+		<input type="checkbox" name="validation_rules<?php echo $count; ?>[]" id="validation_rules<?php echo $count; ?>[]" value="is_numeric" <?php echo set_checkbox('validation_rules'.$count.'[]', 'is_numeric'); ?> /> is_numeric
+	</fieldset>
+</div><!-- end container -->
+<?php
+} // end loop
+?>
+
+<div class="submits">
+	<br />
+	<?php echo form_submit('submit', 'Build the Module'); ?>
+</div>
+<?php echo form_close()?>

--- a/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_form.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_form.php
@@ -1,0 +1,275 @@
+<?php
+	$cur_url = uri_string();
+	$tot = $this->uri->total_segments();
+	$last_seg = $this->uri->segment( $tot);
+
+	if( is_numeric($last_seg) ) {
+		$cur_url = str_replace('/index/'.$last_seg, '', $cur_url);
+	}
+
+?>
+
+<style>
+#module_form label { font-weight: bold; }
+.faded { opacity: .60; }
+.faded:hover, .mb_show_advanced:hover, .mb_show_advanced_rules:hover{ opacity: 1; color: black;}
+.mb_show_advanced, .mb_show_advanced_rules, .container legend { cursor: pointer; }
+.mb_advanced { display: none; }
+</style>
+
+<?php if (validation_errors()) : ?>
+<div class="notification error">
+	<?php echo validation_errors(); ?>
+</div>
+<?php endif; ?>
+
+<div class="notification information">
+	<?php echo lang('mb_form_note'); ?>
+</div>
+
+<?php if ($this->session->flashdata('error')): ?>
+<div class="top_error"><?php echo $this->session->flashdata('error')?></div>
+<?php endif; ?>
+
+
+<?php if ($form_error): ?>
+<div class="important">
+<h4><?php echo lang('mb_form_errors'); ?></h4>
+</div>
+<?php endif; ?>
+
+<?php echo form_open($cur_url."/index/".$field_total."/", array('id'=>"module_form",'class'=>"constrained ajax-form")); ?>
+<div>  
+	<!-- Module Details -->
+	<fieldset style="margin-top: 0" id="module_details">
+		<legend><?php echo lang('mb_form_mod_details'); ?>
+				<em class="mb_show_advanced small"><?php echo lang('mb_form_show_advanced'); ?></em>
+		</legend>
+		<?php echo form_error("module_name"); ?>
+		<?php echo form_error("form_input_delimiters"); ?>
+		<?php echo form_error("form_error_delimiters"); ?>
+		
+		
+		
+		<div>
+			<label for="module_name" class="block"><?php echo lang('mb_form_mod_name'); ?></label>
+			<input name="module_name" id="module_name" type="text" value="<?php echo set_value("module_name"); ?>" placeholder="<?php echo lang('mb_form_mod_name_ph'); ?>" />
+		</div>
+		
+		<div class="mb_advanced">
+			<label for="module_description" class="block"><?php echo lang('mb_form_mod_desc'); ?></label>
+			<input name="module_description" id="module_description" type="text" value="<?php echo set_value("module_description",'Your module description'); ?>" placeholder="<?php echo lang('mb_form_mod_desc_ph'); ?>" />
+		</div>
+
+		<div class="mb_advanced">
+			<label class="block"><?php echo lang('mb_form_contexts'); ?></label>
+			
+			<input name="contexts[]" id="contexts_public" type="checkbox" value="public" checked="checked" /> <?php echo lang('mb_form_public'); ?>
+			<?php foreach (config_item('contexts') as $context) : ?>
+				<input name="contexts[]" id="contexts_<?php echo $context; ?>" type="checkbox" value="<?php echo $context ?>" checked="checked" /> <?php echo ucwords($context) ?>
+			<?php endforeach; ?>
+		</div>
+		
+		<div class="mb_advanced">
+		<?php echo form_error("form_action"); ?>
+			<label for="form_action"><?php echo lang('mb_form_actions'); ?></label>
+
+			<?php foreach($form_action_options as $action => $label): ?>
+			<?php 
+			$data = array(
+				'name'        => 'form_action[]',
+				'id'          => 'form_action_'.$action,
+				'value'       => $action,
+				'checked'     => 'checked'
+				);
+				
+			echo form_checkbox($data); ?> <?php echo $label;?>
+			<?php endforeach;?>
+		</div>
+
+		<div class="mb_advanced">
+			<label for="role_id"><?php echo lang('mb_form_role_id'); ?></label>
+				<?php foreach ($roles as $role) { $all_roles[$role['role_id']] = $role['role_name']; }
+						echo form_dropdown("role_id", $all_roles, set_value("role_id"),'id="role_id"'); ?>
+		 	</select>
+		</div>
+
+		<div>
+			<label for="db_required"><?php echo lang('mb_form_generate'); ?></label>
+			<input name="db_required" id="db_required" type="checkbox" value="1" <?php echo set_checkbox("db_required", "1"); ?> class="checkbox" />
+		</div>
+	</fieldset>
+
+	<fieldset style="margin-top: 0" id="db_details">
+		<legend><?php echo lang('mb_form_table_details'); ?>
+				<em class="mb_show_advanced small"><?php echo lang('mb_form_show_advanced'); ?></em>
+		</legend>
+		
+		<div class="mb_advanced">
+			<label for="table_name" class="block"><?php echo lang('mb_form_table_name'); ?></label>
+			<input name="table_name" id="table_name" type="text" value="<?php echo set_value("table_name"); ?>" placeholder="<?php echo lang('mb_form_table_name_ph'); ?>" />
+		</div>
+		
+		<div class="mb_advanced">
+			<label for="form_input_delimiters" class="block"><?php echo lang('mb_form_delims'); ?></label>
+			<input name="form_input_delimiters" id="form_input_delimiters" type="text" value="<?php echo set_value("form_input_delimiters", '<div>,</div>'); ?>" />
+		</div>
+		
+		<div class="mb_advanced">
+			<label for="form_error_delimiters" class="block"><?php echo lang('mb_form_err_delims'); ?></label>
+			<input name="form_error_delimiters" id="form_error_delimiters" type="text" value="<?php echo set_value("form_error_delimiters", "<span class='error'>,</span>"); ?>" />
+		</div>
+		
+		<div class="mb_advanced">
+			<label for="textarea_editor" class="block"><?php echo lang('mb_form_text_ed'); ?></label>
+			<?php 
+				$textarea_editors = array('' => 'None', 'ckeditor' => 'CKEditor', 'xinha' => 'Xinha');
+			?>
+			<?php echo form_dropdown("textarea_editor", $textarea_editors, set_value("textarea_editor"),'id="textarea_editor"'); ?>
+		</div>
+			
+		<div class="notification attention">
+			<?php echo lang('mb_table_note'); ?>
+		</div>
+		
+		<div>
+			<label for="primary_key_field" class="block"><?php echo lang('mb_form_primarykey'); ?></label>
+			<input name="primary_key_field" id="primary_key_field" type="text" value="<?php echo set_value("primary_key_field", 'id'); ?>" />
+		</div>
+	
+		<div id="field_numbers">
+			<label class="block"><?php echo lang('mb_form_fieldnum'); ?></label> 
+			<?php 
+			$field_num_count = count($field_numbers);
+			for($ndx=0; $ndx < $field_num_count; $ndx++): ?>
+			<a href="<?php echo site_url($cur_url."/index/{$field_numbers[$ndx]}"); ?>" <?php if ($field_numbers[$ndx] == $field_total) { echo 'class="current"'; } ?>><?php echo $field_numbers[$ndx]; ?></a><?php echo $ndx < $field_num_count - 1 ? ' | ' : '';?>
+			<?php endfor; ?>
+		</div>
+	</fieldset>
+</div>
+
+
+<div id="all_fields">
+	<?php
+	for ($count = 1; $count <= $field_total; $count++) : // loop to build fields ?>
+	
+		<div class="container <?php if ($count % 2): ?>left<?php endif;?>">  
+			<fieldset id="field<?php echo $count; ?>_details">
+				<legend><?php echo lang('mb_form_field_details'); ?> <?php echo $count; ?></legend>
+				
+				<?php if ($count == 1) : ?>
+					
+				<div class="notification information">
+					<?php echo lang('mb_field_note'); ?>
+				</div>
+				
+				<?php endif; ?>								
+		
+				<?php echo form_error("view_field_label{$count}"); ?>
+				<?php echo form_error("view_field_name{$count}"); ?>
+				<?php echo form_error("view_field_type{$count}"); ?>
+		
+				<div>
+		
+				<label for="view_field_label<?php echo $count; ?>"><?php echo lang('mb_form_label'); ?></label>
+		
+				<input name="view_field_label<?php echo $count; ?>" id="view_field_label<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_label{$count}"); ?>" placeholder="<?php echo lang('mb_form_label_ph'); ?>" />
+				</div>
+		
+				<div>
+				<label for="view_field_name"><?php echo lang('mb_form_fieldname'); ?></label>
+				<input name="view_field_name<?php echo $count; ?>" id="view_field_name<?php echo $count; ?>" type="text" value="<?php echo set_value("view_field_name{$count}"); ?>" maxlength="30" placeholder="<?php echo lang('mb_form_fieldname_ph'); ?>" />
+				</div>
+		
+				<div>
+				<label for="view_field_type<?php echo $count; ?>"><?php echo lang('mb_form_type'); ?></label>
+		
+				<?php
+				$view_field_types = array(
+										'input' 	=> 'INPUT',
+										'textarea' 	=> 'TEXTAREA',
+										'select' 	=> 'SELECT',
+										'radio' 	=> 'RADIO',
+										'checkbox' 	=> 'CHECKBOX',
+										'password' 	=> 'PASSWORD'
+										);
+				?>
+				<?php echo form_dropdown("view_field_type{$count}", $view_field_types, set_value("view_field_type{$count}"),'id="view_field_type'.$count.'"'); ?>
+				</div>
+		
+				<?php echo form_error("db_field_type{$count}"); ?>
+		
+				<div>
+				<label for="db_field_type<?php echo $count; ?>"><?php echo lang('mb_form_dbtype'); ?></label>
+		
+				<?php
+				$db_field_types = array(
+										'VARCHAR' 		=> 'VARCHAR',
+										'TINYINT' 		=> 'TINYINT',
+										'TEXT' 			=> 'TEXT',
+										'DATE' 			=> 'DATE',
+										'SMALLINT' 		=> 'SMALLINT',
+										'MEDIUMINT' 	=> 'MEDIUMINT',
+										'INT' 			=> 'INT',
+										'BIGINT' 		=> 'BIGINT',
+										'FLOAT' 		=> 'FLOAT',
+										'DOUBLE' 		=> 'DOUBLE',
+										'DECIMAL' 		=> 'DECIMAL',
+										'DATETIME' 		=> 'DATETIME',
+										'TIMESTAMP' 	=> 'TIMESTAMP',
+										'TIME' 			=> 'TIME',
+										'YEAR' 			=> 'YEAR',
+										'CHAR' 			=> 'CHAR',
+										'TINYBLOB' 		=> 'TINYBLOB',
+										'TINYTEXT' 		=> 'TINYTEXT',
+										'BLOB' 			=> 'BLOB',
+										'MEDIUMBLOB' 	=> 'MEDIUMBLOB',
+										'MEDIUMTEXT' 	=> 'MEDIUMTEXT',
+										'LONGBLOB' 		=> 'LONGBLOB',
+										'LONGTEXT' 		=> 'LONGTEXT',
+										'ENUM' 			=> 'ENUM',
+										'SET' 			=> 'SET',
+										'BIT' 			=> 'BIT',
+										'BOOL' 			=> 'BOOL',
+										'BINARY' 		=> 'BINARY',
+										'VARBINARY' 	=> 'VARBINARY'
+										);
+				?>
+				<?php echo form_dropdown("db_field_type{$count}", $db_field_types, set_value("db_field_type{$count}"),'id="db_field_type'.$count.'"'); ?>
+		
+				</div>
+		
+				<?php echo form_error("db_field_length_value{$count}"); ?>
+				
+				<div>
+				<label for="db_field_length_value<?php echo $count; ?>"><?php echo lang('mb_form_length'); ?></label>
+				<input name="db_field_length_value<?php echo $count; ?>" id="db_field_length_value<?php echo $count; ?>" type="text" value="<?php echo set_value("db_field_length_value{$count}"); ?>" placeholder="<?php echo lang('mb_form_length_ph'); ?>" />
+				</div>
+		
+				<div>
+				<label><?php echo lang('mb_form_rules'); ?></label>
+		
+				<?php echo form_error('cont_validation_rules'.$count.'[]'); ?>
+				
+				<?php foreach ($validation_rules as $validation_rule) : ?>
+					<span class="faded"> <input name="validation_rules<?php echo $count; ?>[]" id="validation_rules_<?php echo $validation_rule; ?><?php echo $count; ?>" type="checkbox" value="<?php echo $validation_rule; ?>" <?php echo set_checkbox('validation_rules'.$count.'[]', $validation_rule); ?> /> <?php echo lang('mb_form_'.$validation_rule); ?></span> 
+				<?php endforeach; ?>
+					<em class="mb_show_advanced_rules small"><?php echo lang('mb_form_show_more'); ?></em>
+				</div>
+				
+				<div class="mb_advanced">
+				<label><?php echo lang('mb_form_rules_limits'); ?></label>
+				<?php echo lang('mb_form_rules_limit_note'); ?>
+				<?php foreach ($validation_limits as $validation_limit) : ?>
+					<span class="faded"><input name="validation_rules<?php echo $count; ?>[]" id="validation_rules_<?php echo $validation_limit; ?><?php echo $count; ?>" type="radio" value="<?php echo $validation_limit; ?>" <?php echo set_radio('validation_rules'.$count.'[]', $validation_limit); ?> /> <?php echo lang('mb_form_'.$validation_limit); ?></span> 
+				<?php endforeach; ?>
+				</div>
+			</fieldset>
+		</div><!-- end container -->
+	<?php endfor; ?>
+</div>
+<div class="submits">
+	<br />
+	<?php echo form_submit('submit', 'Build the Module'); ?>
+</div>
+<?php echo form_close()?>

--- a/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_js.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_js.php
@@ -1,0 +1,105 @@
+function verify_delete(module_name) {
+	
+    var verify = confirm('Are you sure you wish to delete module "'+module_name+'"?')
+    
+    if (verify) {
+        var url = '<?php echo site_url(SITE_AREA .'/developer/modulebuilder/delete/') ?>/'+ module_name;
+        window.location.href = url
+    }
+    
+    // this is for the icon click delete, doesn't like event.preventDefault();
+    return false;
+}
+
+function show_table_props() {
+	if ($('#db_required').is(':checked')) {
+		$('#db_details').show(0);
+		$('#all_fields').show(0);
+		var tbl_name = ( ( $('#table_name').val() == '' ) ? $('#module_name').val() : $('#table_name').val() );
+		tbl_name = tbl_name.replace(/[^A-Za-z0-9\\s]/g, "_").toLowerCase();
+		$('#table_name').val( tbl_name );
+	} else {
+		$('#db_details').hide(0);
+		$('#all_fields').hide(0);
+	}
+}
+
+function store_form_data() {
+	// loop through all the inputs and get the data
+	$('#module_form :input').each( function() {
+		var fld_id = $(this).attr('id');
+		var fld_val = $(this).val();
+		
+		if ( $(this).is(':checkbox') && $(this).is(':not(:checked)') ) {
+			fld_val = 'uncheck';
+		}
+
+		if (fld_id && fld_val) {
+			localStorage[fld_id] = fld_val;
+		}
+	});
+}
+
+function get_form_data() {
+	for (var i = 0; i < localStorage.length; i++){
+		var key = localStorage.key(i);
+    	var value = localStorage[key];
+		
+		if ( $('#'+key).is(':checkbox') ) {
+			if ( $('#'+key).val() == value ) {
+				$('#'+key).attr('checked','checked');
+			} else {
+				$('#'+key).removeAttr('checked');
+				//restore the proper value
+				value = $('#'+key).val();
+			}
+		}
+		
+		$('#'+key).val(value);
+	}
+	
+	//now that it is loaded, remove localStorage
+	localStorage.clear();
+}
+
+if (localStorage.length >= 1) {
+	get_form_data();
+}
+
+$.subscribe('list-view/list-item/click', function(module_name) {
+    verify_delete(module_name);
+});
+
+$('.confirm_delete').click(function(event) {
+	event.stopImmediatePropagation();
+	event.preventDefault();
+    verify_delete($(this).attr('title'));    
+});
+
+$('#field_numbers a').click( function() {
+	// need to grab all the information to reload it. since db_details already has an id, we can store the data there.
+	store_form_data();
+});
+
+$('#module_form').submit( function() {
+	// need to grab all the information to reload it. since db_details already has an id, we can store the data there.
+	store_form_data();
+});
+
+show_table_props();
+$('#db_required').click( function() {
+	show_table_props();
+});
+
+$('.mb_show_advanced').click( function() {
+	var parent = $(this).closest('fieldset').attr('id');
+	$('#'+parent+' .mb_advanced').toggle();
+});
+
+$('.mb_show_advanced_rules').click( function() {
+	$(this).parent().next('.mb_advanced').toggle();
+});
+
+$('.container legend').click( function() {
+	$(this).parent('fieldset').children('div:not(".mb_advanced:hidden")').toggle();
+});

--- a/bonfire/application/core_modules/modulebuilder/views/developer/output.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/output.php
@@ -7,43 +7,65 @@
 		$cur_url = str_replace('/'.$last_seg, '', $cur_url);
 	}
 ?>
-	<p>Below you will find the code for the Controller and View files. Model and SQL files will be included if you selected the DB Required option and a Javascript file if you so required.</p>
+<div class="notification success">
+	<p><?php echo lang('mb_out_success'); ?></p>
+	<br />
+	<p><b><?php echo lang('mb_out_success_note'); ?></b></p>
+</div>
 
-	<p><b>NOTE: Please add extra user input validation as you require.  This code is to be used as a starting point only.</b></p>
+<div class="notification attention">
+	<?php printf(lang('mb_out_tables'), anchor(SITE_AREA .'/developer/migrations#mod-tab', 'Migrations')) ;?>
+</div>
 
 <p class="important">
-<?php if (!isset($error)): ?>
-<?php echo $error?>
-<?php endif; ?> 
+<?php
+	if (!isset($error)) {
+		echo $error;
+	};
+?> 
 </p>
 
-	<h4>Controller files</h4>
-	<p>
-	<?php  foreach($controllers as $controller_name => $val): ?>
-	controllers/<?php echo $controller_name;?>.php<br />
-	<?php endforeach; ?>
-	</p>
-
-<?php if($model): ?>
-	<h4>Model file</h4>
-	<p><?php echo $module_name_lower;?>_model.php</p>
+<?php if($acl_migration): ?>
+<h4><?php echo lang('mb_out_acl'); ?></h4>
+<p><?php echo sprintf(lang('mb_out_acl_path'),$module_name_lower); ?>
 <?php endif; ?>
+
+<?php if($build_config): ?>
+<h4><?php echo lang('mb_out_config'); ?></h4>
+<p><?php echo lang('mb_out_config_path'); ?></p>
+<?php endif; ?>
+
+<h4><?php echo lang('mb_out_controller'); ?></h4>
+<p>
+<?php
+foreach($controllers as $controller_name => $val) {
+	echo sprintf(lang('mb_out_controller_path'),$controller_name).'<br />';
+}
+?>
+</p>
 
 <?php if($lang): ?>
-	<h4>Language file</h4>
-	<p><?php echo $module_name_lower;?>_lang.php</p>
+<h4><?php echo lang('mb_out_lang'); ?></h4>
+<p><?php echo sprintf(lang('mb_out_lang_path'),$module_name_lower); ?></p>
 <?php endif; ?>
 
-	<h4>View files</h4>
-	<p>
-	<?php foreach($views as $context_name => $context_views): ?>
-		<?php  foreach($context_views as $view_name => $val): ?>
-		views/<?php echo $context_name == $module_name_lower ? $view_name : $context_name."/".$view_name;?>.php<br />
-		<?php endforeach; ?>
-	<?php endforeach; ?>
-	</p>
-
-<?php if($migration): ?>
-	<h4>Migration file</h4>
-	<p>migrations/001_Install_<?php echo $module_name_lower;?>.php</p>
+<?php if($db_migration): ?>
+<h4><?php echo lang('mb_out_migration'); ?></h4>
+<p><?php echo sprintf(lang('mb_out_migration_path'),$module_name_lower); ?></p>
 <?php endif; ?>
+
+<?php if($model): ?>
+<h4><?php echo lang('mb_out_model'); ?></h4>
+<p><?php echo sprintf(lang('mb_out_model_path'),$module_name_lower); ?></p>
+<?php endif; ?>
+
+<h4><?php echo lang('mb_out_view'); ?></h4>
+<p>
+<?php
+foreach($views as $context_name => $context_views){
+	foreach($context_views as $view_name => $val){
+		echo sprintf(lang('mb_out_view_path'),( $context_name == $module_name_lower ? $view_name : $context_name."/".$view_name)).'<br />';
+	}
+}
+?>
+</p>

--- a/bonfire/application/core_modules/modulebuilder/views/files/acl_migration.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/acl_migration.php
@@ -1,37 +1,13 @@
 <?php
 
-$migrations = '<?php if (!defined(\'BASEPATH\')) exit(\'No direct script access allowed\');
+$acl_migrations = '<?php if (!defined(\'BASEPATH\')) exit(\'No direct script access allowed\');
 
-class Migration_Install_'.$module_name_lower.' extends Migration {
+class Migration_Install_'.$module_name_lower.'_permissions extends Migration {
 	
 	public function up() 
 	{
 		$prefix = $this->db->dbprefix;
 
-		$this->dbforge->add_field(\'`'.$primary_key_field.'` int(11) NOT NULL AUTO_INCREMENT\');';
-		for($counter=1; $field_total >= $counter; $counter++)
-		{
-			//Due to the requiredif rule if the first field is set the the others must be
-			if (set_value("view_field_label$counter") == NULL)
-			{
-				continue; 	// move onto next iteration of the loop
-			}
-
-		$migrations .= '
-		$this->dbforge->add_field(\'`'.set_value("view_field_name$counter").'` '.set_value("db_field_type$counter");
-		
-			if (!in_array(set_value("db_field_type$counter"), array('TEXT', 'DATE', 'DATETIME'))) // There are no doubt more types where a value/length isn't possible - needs investigating
-			{
-				$migrations .= '('.set_value("db_field_length_value$counter").')';
-			}
-		
-
-		$migrations .= ' NOT NULL\');';
-		
-		}
-		$migrations .= '
-		$this->dbforge->add_key(\''.$primary_key_field.'\', true);
-		$this->dbforge->create_table(\''.$module_name_lower.'\');
 
 		// permissions';
 		foreach($contexts as $context) {
@@ -47,14 +23,14 @@ class Migration_Install_'.$module_name_lower.' extends Migration {
 						$action_name = 'View';
 					}
 					$action_permission = $permission . $action_name;
-					$migrations .= '
-					$this->db->query("INSERT INTO {$prefix}permissions VALUES (0,\''.$action_permission.'\',\'\',\'active\');");';
+					$acl_migrations .= '
+					$this->db->query("INSERT INTO {$prefix}permissions VALUES (0,\''.$action_permission.'\',\'\',\'active\');");
+					$this->db->query("INSERT INTO {$prefix}role_permissions VALUES ('.$role_id.',".$this->db->insert_id().");");';
 				}
 			}
 		}
 
-		$migrations .= '
-
+		$acl_migrations .= '
 	}
 	
 	//--------------------------------------------------------------------
@@ -63,8 +39,7 @@ class Migration_Install_'.$module_name_lower.' extends Migration {
 	{
 		$prefix = $this->db->dbprefix;
 
-		$this->dbforge->drop_table(\''.$module_name_lower.'\');
-		// permissions';
+        // permissions';
 		foreach($contexts as $context) {
 			if ($context != 'public')
 			{
@@ -78,7 +53,7 @@ class Migration_Install_'.$module_name_lower.' extends Migration {
 						$action_name = 'View';
 					}
 					$action_permission = $permission . $action_name;
-					$migrations .= '
+					$acl_migrations .= '
 					$query = $this->db->query("SELECT permission_id FROM {$prefix}permissions WHERE name=\''.$action_permission.'\';");
 					foreach ($query->result_array() as $row)
 					{
@@ -90,12 +65,12 @@ class Migration_Install_'.$module_name_lower.' extends Migration {
 			}
 		}
 
-		$migrations .= '
+		$acl_migrations .= '
 	}
 	
 	//--------------------------------------------------------------------
 	
 }';
 
-echo $migrations;
+echo $acl_migrations;
 ?>

--- a/bonfire/application/core_modules/modulebuilder/views/files/config.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/config.php
@@ -1,0 +1,14 @@
+<?php
+
+$build_config = '<?php if ( ! defined(\'BASEPATH\')) exit(\'No direct script access allowed\');';
+
+$build_config .= '$config[\'module_config\'] = array(
+	\'description\'	=> \''.$module_description.'\',
+	\'name\'		=> \''.$module_name.'\',
+	\'version\'		=> \'0.0.1\',
+	\'author\'		=> \''.$this->auth->username().'\'
+);
+';
+
+echo $build_config;
+?>

--- a/bonfire/application/core_modules/modulebuilder/views/files/controller.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/controller.php
@@ -202,8 +202,8 @@ $controller .= '
 		for($counter=1; $field_total >= $counter; $counter++)
 		{
 			// only build on fields that have data entered. 
-	
-			//Due to the requiredif rule if the first field is set the the others must be
+				
+			// Due to the required if rule if the first field is set the the others must be
 	
 			if (set_value("view_field_label$counter") == NULL)
 			{
@@ -232,7 +232,12 @@ $controller .= '
 						$controller .= '|';
 					}
 				
-					$controller .= $value;
+					if ($value == 'unique')	{		
+						$prefix = $this->db->dbprefix;
+						$controller .= $value.'['.$prefix.$table_name.'.'.set_value("view_field_name$counter").']';
+					} else {
+						$controller .= $value;	
+					}
 					$rule_counter++;
 				}
             }

--- a/bonfire/application/core_modules/modulebuilder/views/files/db_migration.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/db_migration.php
@@ -1,0 +1,53 @@
+<?php
+
+$db_migration = '<?php if (!defined(\'BASEPATH\')) exit(\'No direct script access allowed\');
+
+class Migration_Install_'.$table_name.' extends Migration {
+	
+	public function up() 
+	{
+		$prefix = $this->db->dbprefix;
+
+		$this->dbforge->add_field(\'`'.$primary_key_field.'` int(11) NOT NULL AUTO_INCREMENT\');';
+		for($counter=1; $field_total >= $counter; $counter++)
+		{
+			//Due to the requiredif rule if the first field is set the the others must be
+			if (set_value("view_field_label$counter") == NULL)
+			{
+				continue; 	// move onto next iteration of the loop
+			}
+
+			$db_migration .= '
+			$this->dbforge->add_field(\'`'.strtolower(set_value("view_field_name$counter")).'` '.set_value("db_field_type$counter");
+		
+			if (!in_array(set_value("db_field_type$counter"), array('TEXT', 'DATE', 'DATETIME'))) // There are no doubt more types where a value/length isn't possible - needs investigating
+			{
+				$db_migration .= '('.set_value("db_field_length_value$counter").')';
+			}
+		
+
+		$db_migration .= ' NOT NULL\');';
+		
+		}
+		$db_migration .= '
+		$this->dbforge->add_key(\''.$primary_key_field.'\', true);
+		$this->dbforge->create_table(\''.$table_name.'\');
+
+	}
+	
+	//--------------------------------------------------------------------
+	
+	public function down() 
+	{
+		$prefix = $this->db->dbprefix;
+
+		$this->dbforge->drop_table(\''.$table_name.'\');
+
+	}
+	
+	//--------------------------------------------------------------------
+	
+}';
+
+echo $db_migration;
+?>

--- a/bonfire/application/core_modules/modulebuilder/views/files/model.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/model.php
@@ -3,7 +3,7 @@ $model = '<?php if (!defined(\'BASEPATH\')) exit(\'No direct script access allow
 
 class '.ucfirst($controller_name).'_model extends BF_Model {
 
-	protected $table		= "'.$controller_name.'";
+	protected $table		= "'.$table_name.'";
 	protected $key			= "'.$primary_key_field.'";
 	protected $soft_deletes	= false;
 	protected $date_format	= "datetime";

--- a/bonfire/application/core_modules/modulebuilder/views/files/view_index.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/view_index.php
@@ -13,8 +13,8 @@ $view = '
 					<?php $record = (array)$record;?>
 					<div class="list-item" data-id="<?php echo $record[\''.$primary_key_field.'\']; ?>">
 						<p>
-							<b><?php echo $record[\''.$primary_key_field.'\']; ?></b><br/>
-							<span class="small"><?php echo lang(\''.$module_name_lower.'_edit_text\'); ?></span>
+							<b><?php echo (empty($record[\'name\']) ? $record[\''.$primary_key_field.'\'] : $record[\'name\']); ?></b><br/>
+							<span class="small"><?php echo (empty($record[\'description\']) ? lang(\''.$module_name_lower.'_edit_text\') : $record[\'description\']);  ?></span>
 						</p>
 					</div>
 				<?php endforeach; ?>
@@ -73,7 +73,7 @@ foreach ($records as $record) : ?>
 	{
 		if($field != "'.$primary_key_field.'") {
 ?>
-				<td><?php echo $value;?></td>
+				<td><?php echo ($field == \'deleted\') ? (($value > 0) ? \'True\' : \'False\') : $value; ?></td>
 
 <?php
 		}

--- a/bonfire/application/core_modules/modulebuilder/views/files/view_index_alt.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/view_index_alt.php
@@ -41,7 +41,7 @@ foreach ($records as $record) : ?>
 	{
 		if($field != "'.$primary_key_field.'") {
 ?>
-				<td><?php echo $value;?></td>
+				<td><?php echo ($field == \'deleted\') ? (($value > 0) ? \'True\' : \'False\') : $value; ?></td>
 
 <?php
 		}

--- a/bonfire/application/db/migrations/core/009_Add_module_permissions.php
+++ b/bonfire/application/db/migrations/core/009_Add_module_permissions.php
@@ -1,0 +1,33 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_Add_module_permissions extends Migration {
+	
+	public function up() 
+	{
+		$prefix = $this->db->dbprefix;
+				
+		$this->db->query("INSERT INTO {$prefix}permissions(name, description) VALUES('Bonfire.Modules.Add','Allow creation of modules with the builder.')");
+		$this->db->query("INSERT INTO {$prefix}permissions(name, description) VALUES('Bonfire.Modules.Delete','Allow deletion of modules.')");
+		
+	}
+	
+	//--------------------------------------------------------------------
+	
+	public function down() 
+	{
+		$prefix = $this->db->dbprefix;
+		
+		$query = $this->db->query("SELECT permission_id FROM {$prefix}permissions WHERE name = 'Bonfire.Modules.Add' OR name = 'Bonfire.Modules.Delete'");
+		foreach ($query->result_array() as $row)
+		{
+			$permission_id = $row['permission_id'];
+			$this->db->query("DELETE FROM {$prefix}role_permissions WHERE permission_id='$permission_id';");
+		}
+				
+		$this->db->query("DELETE FROM {$prefix}permissions WHERE (name = 'Bonfire.Modules.Add')");
+		$this->db->query("DELETE FROM {$prefix}permissions WHERE (name = 'Bonfire.Modules.Delete')");
+	}
+	
+	//--------------------------------------------------------------------
+	
+}

--- a/bonfire/application/libraries/MY_Form_validation.php
+++ b/bonfire/application/libraries/MY_Form_validation.php
@@ -1,0 +1,62 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class MY_Form_validation extends CI_Form_validation {
+    
+    /**
+     * MY_Form_validation::__construct()
+     * 
+     * @return
+     */
+    function __construct() {
+        parent::__construct();      
+    }
+
+	// --------------------------------------------------------------------
+                                   
+	/**
+	 * MY_Form_validation::unique()
+	 * 
+	 * i.e. '...|required|unique[bf_users.name]|trim...'
+	 * 
+     * @abstract Rule to force value to be unique in table
+     * @usage "unique[tablename.fieldname]"
+	 * @param mixed $value the value to be checked
+	 * @param mixed $params the table and field to check against
+	 * @return bool
+	 */
+	function unique($value, $params) {
+		$this->CI->form_validation->set_message('unique', 'The value in &quot;%s&quot; is already being used.');
+
+		list($table, $field) = explode(".", $params, 2);
+
+		$query = $this->CI->db->select($field)->from($table)
+			->where($field, $value)->limit(1)->get();
+
+		if ($query->row()) {
+			return false;
+		} else {
+			return true;
+		}
+
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * MY_Form_validation::alpha_extra()
+     * 
+	 * @abstract Alpha-numeric with periods, underscores, spaces and dashes
+     * @param string $str
+	 * @return	bool
+	 */
+	function alpha_extra($str)
+	{
+		$this->CI->form_validation->set_message('alpha_extra', 'The %s field may only contain alpha-numeric characters, spaces, periods, underscores, and dashes.');
+		return ( ! preg_match("/^([\.\s-a-z0-9_-])+$/i", $str)) ? FALSE : TRUE;
+	}
+
+	// --------------------------------------------------------------------
+}
+
+/* Author :  http://net.tutsplus.com/tutorials/php/6-codeigniter-hacks-for-the-masters/ */
+/* End of file : ./libraries/MY_Form_validation.php */


### PR DESCRIPTION
Reworked Modulebuilder to look like the rest of the admin pages. There is so many changes gonna try and list them all out. I read over the notes on that link to where you guys discussed changing the modulebuilder to have more jquery goodness and have a better UserXperience.

I incorporated as many of those changes as I thought was possible and part of the UX reworking. But I tried not to make to many "engine" changes and focused on the ux so some of daK76's core code changes weren't incorporated because 1) I never saw the old interface he is wistfully recalling :) and 2) it was pretty far outside the scope of what I was doing. But I did try to streamline it for him. :) You can build a functional, table-less, module by filling out only one field (module name) and clicking the build button.

I was able to get the "dynamically add fields via jquery button" to work, kinda, but I could never get the validation checks to work properly on them. And I don't know how long it will take to troubleshoot and fix so I rolled it back to "choose your number of fields" but I think it looks a bit more slick and less daunting than before.

Seems I forgot to delete the "index_old.php" file. I will delete that and comment the javascript functions in the next day or two (pretty tired of this builder now heh) but I have created and deleted about 15 dozen modules with it now, trying very hard to break it and it seems pretty solid.

I will get working on the dynamically adding fields working with validation errors, again, but I am thinking it is going to take some time to sort that rotten bugger.

---

The list of changes: 

Added a language file and stripped out all hardcoded text (I think..whew).

Added a javascript file to the views for ux goodness.

Separated out the form from the index.

HTML5 placeholders.

HTML5 localStorage for temporary holding of data when choosing fields so no re-enter of module name, etc...

Lots of UX shifts/re-orgs/changes to make the builder a little easier.

Create Module hides "advanced options" until toggled. Module name and Create Table only visible fields initially.

Module database table options hidden until "db_required" checkbox is clicked.

Added the ability to change the table name. Defaults to module_name.toLowerCase() with space to underscore checking.

Module database table advanced options hidden until toggled. Primary Key and # of fields only visible initially.

Separated out validation "rules" from "input limitations". (but they are all still codeigniter validation rules)

Validation rules (4 of them) are checkboxes.

Input limitations are radio buttons and are hidden by default.

Created two new validation rules in MY_Form_validation.php : alpha_extra (alphanumerics plus dashes, underscores, spaces and periods) for textareas and unique (forces value to be unique in table...i.e. username)

Added a delete option, with confirmation, to list of modules in sidebar and on index page.

Added two new bonfire permissions "Bonfire.Modules.Add" and "Bonfire.Modules.Delete".

Created migration page for bonfire permission additions.

Changed the "migrations" that were created into two separate migration files. 1 to add the necessary module permissions and 1 to add the requested table.

Added the ability to give a role the full module permissions in the module permissions migration.

If a "name" and / or "description" field exist in the created module table the created controllers will show that information in the sidebar instead of the id and generic "edit this text".

If there is a "deleted" field in the created module, the created controllers will show True/False depending on the value of the deleted field.

Modulebuilder now creates a config file for the modules with provided information.

Results page (output.php) mostly unscathed..just some language changes.
