### PR TITLE
#117 Added SSL support for Assets library

### DIFF
--- a/bonfire/application/libraries/assets.php
+++ b/bonfire/application/libraries/assets.php
@@ -647,7 +647,7 @@ class Assets {
 		else 
 		{
 			
-			//
+			//Check for HTTPS or HTTP connection
 			
 			if(isset($_SERVER['HTTPS'])){ $http_protocol = "https";} else { $http_protocol = "http";}
 		
@@ -1145,6 +1145,7 @@ class Assets {
 			// Strip out the file type for consistency
 			$file = str_replace($type, '', $file);
 			
+			//Check for HTTPS or HTTP connection
 			if(isset($_SERVER['HTTPS'])){ $http_protocol = "https";} else { $http_protocol = "http";}
 			
 			// If it contains an external URL, we're all done here.


### PR DESCRIPTION
Cheap but Cheerful SSL support for the Asset library and then I believe the whole of Bonfire works correctly on SSL. 

I have issued this as a pull request as I didn't know whether you guys think it's worth it until SSL support is enriched using the library daK76 suggested within the issue #117
