### PR TITLE
External js from https source should load correctly on http website

### DIFF
--- a/bonfire/application/libraries/assets.php
+++ b/bonfire/application/libraries/assets.php
@@ -659,7 +659,9 @@ class Assets {
 				}
 			
 				$attr = array(
-					'src'	=> strpos($script, $http_protocol . ':') !== false ?
+					'src'	=> (strpos($script, $http_protocol . ':') !== false || 
+                                        strpos($script, 'http:') !== false || 
+                                        strpos($script, 'https:') !== false ) ?
 						
 						// It has a full url built in, so leave it alone
 						$script :


### PR DESCRIPTION
Fixed external_js for assets to load external js https files on http website and vice versa.

Now when I am adding external js:

```
Assets::add_js( array(
            'https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js',
), 'external');
```

I get:
head.js("http://mysite/assets/js/https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js");

but it should be:

head.js("http://mysite/assets/js/https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js");
