### PR TITLE
Changed config_item to use $this->_settings_lib for Site Titles

### DIFF
--- a/bonfire/themes/default/index.php
+++ b/bonfire/themes/default/index.php
@@ -9,7 +9,7 @@
 <head>
 	<meta charset="UTF-8" />
 	
-	<title><?php echo config_item('site.title'); ?></title>
+	<title><?php echo $this->settings_lib->item('site.title'); ?></title>
 	
 	<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
 
@@ -23,7 +23,8 @@
 	
 		<!-- Header -->
 		<div class="head text-right">
-			<h1>Bonfire</h1>
+
+			<h1><?php echo $this->settings_lib->item('site.title'); ?> - Testing Platform</h1>
 		</div>
 
 		<div class="main">


### PR DESCRIPTION
Noticed in a site i'm setting up that the Site Title in the Default template is still pulling from the config file.

Personally I think the Core Module Variables should probably be pulled into there own array of variables in the Main Controller to reduce the amount of code needed to use them.
