### PR TITLE
Fix Line 27 $error_message undefined variable modulebuilder

### DIFF
--- a/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_form.php
+++ b/bonfire/application/core_modules/modulebuilder/views/developer/modulebuilder_form.php
@@ -23,7 +23,7 @@
 		<?php echo validation_errors(); ?>
 	</div>
 	<?php endif; ?>
-	<?php if (validation_errors() || isset($error_message)) : ?>
+	<?php if ( isset($error_message) ) : ?>
 	<div class="notification error"><?php echo $error_message?></div>
 	<?php endif; ?>
 	


### PR DESCRIPTION
Fixed Line 27 error when building a module with a bad name or other validation error.

```
Removed validation_errors() ||
```

Since they are being checked and echoed before the $error_message variable
