### PR TITLE
Assets::add_module_js() causes fatal error unknown function module_file_path();

### DIFF
--- a/bonfire/application/config/autoload.php
+++ b/bonfire/application/config/autoload.php
@@ -64,7 +64,7 @@ $autoload['libraries'] = array('database','template', 'assets', 'events', 'setti
 |	$autoload['helper'] = array('url', 'file');
 */
 
-$autoload['helper'] = array('url', 'language');
+$autoload['helper'] = array('url', 'language', 'application');
 
 
 /*


### PR DESCRIPTION
Added application_helper to autoload config to fix error with Assets::add_module_js() causing fatal error

Assets::add_module_js() causes fatal error unknown function module_file_path();
