### PR TITLE
Added globals flag to Assets to conditonally turn off global includes

### DIFF
--- a/bonfire/application/libraries/assets.php
+++ b/bonfire/application/libraries/assets.php
@@ -113,6 +113,13 @@ class Assets {
 	*/
 	private static $module_styles		= array();
 
+    /*
+         Var: $globals
+
+         Flag to define is global includes should be rendered
+         on css() and js() output or supressed.
+     */
+    private static $globals					= true;
 
 	//--------------------------------------------------------------------
 
@@ -167,6 +174,24 @@ class Assets {
 
 	//--------------------------------------------------------------------
 
+    //--------------------------------------------------------------------
+    // !GLOBAL METHODS
+    //--------------------------------------------------------------------
+    /*
+         Method: set_globals()
+
+         Set the value of the static $globals flag that determines if
+         global includes (like the default media type CSS and global.js files)
+         are automatically included in css() and js() output.
+
+         Parameters:
+             $include	- TRUE to include (default) or FALSE to exclude
+         Return:
+            <void>
+     */
+    public static function set_globals($include = true) {
+        self::$globals = $include;
+    }
 
 	//--------------------------------------------------------------------
 	// !STYLESHEET METHODS
@@ -198,7 +223,7 @@ class Assets {
 		$return = '';
 
 		// If no style(s) has been passed in, use all that have been added.
-		if (empty($style))
+		if (empty($style) && self::$globals)
 		{
 			// Make sure to include a file based on media type.
 			$styles[] = array(
@@ -630,7 +655,7 @@ class Assets {
 		}
 
 		// Make sure we check for a 'global.js' file.
-		$scripts[] = 'global';
+        if (self::$globals) { $scripts[] = 'global'; }
 
 		// Add a style named for the controller so it will be looked for.
 		$scripts[] = self::$ci->router->class;


### PR DESCRIPTION
Based on a question posed on the forums, I added a way to conditionally turn off global css and js includes via an Assets::set_globals([true|false]) method.
