### PR TITLE
Temporary fix to remove `array to string` conversion errors in PHP 5.4

### DIFF
--- a/bonfire/codeigniter/database/DB_active_rec.php
+++ b/bonfire/codeigniter/database/DB_active_rec.php
@@ -1398,10 +1398,6 @@ class CI_DB_active_record extends CI_DB_driver {
 				{
 					$index_set = TRUE;
 				}
-				else
-				{
-					$not[] = $k.'-'.$v;
-				}
 
 				if ($escape === FALSE)
 				{


### PR DESCRIPTION
Until CI is updated PHP 5.4 will get `array to string` conversion errors when using the batch update.
See https://github.com/EllisLab/CodeIgniter/issues/1273 for bug info.

This commit simply removes the redundant (and error causing) if block.
