### PR TITLE
Remove misplaced text before php tag that displayed in IE

### DIFF
--- a/bonfire/themes/default/parts/_header.php
+++ b/bonfire/themes/default/parts/_header.php
@@ -1,4 +1,4 @@
-css<?php
+<?php
 	// Setup our default assets to load.
 	Assets::add_js( 'bootstrap.min.js' );
 	Assets::add_css( array('bootstrap.min.css', 'bootstrap-responsive.min.css'));


### PR DESCRIPTION
The text css was inserted before the doctype declaration. Most browsers ignored it, but IE displayed it above the navbar
