### PR TITLE
include_once in event handlers

### DIFF
--- a/bonfire/application/libraries/events.php
+++ b/bonfire/application/libraries/events.php
@@ -128,7 +128,7 @@ class Events
 				continue;
 			}
 
-			@include($file_path);
+			@include_once($file_path);
 
 			if (!class_exists($subscriber['class']))
 			{


### PR DESCRIPTION
Sorry about the last one, github got the better of me.

When one file defines event handlers for multiple events, pages that
used those events would not display and/or the events would not fire
properly. Fix found at
http://forums.cibonfire.com/discussion/comment/1388#Comment_1388
