### PR TITLE
Filter selection on '.btn' selector before applying click event, replace...

### DIFF
--- a/bonfire/application/core_modules/activities/views/reports/activities_js.php
+++ b/bonfire/application/core_modules/activities/views/reports/activities_js.php
@@ -12,16 +12,14 @@ function verify_delete(whom, action) {
     return false;
 }
 
-$('.btn').not('[id="tb_email"]').click( function(event) {
-	if (typeof $(this).attr('id') !== 'undefined') {
-		var which = $(this).attr('id').replace('delete-', '');
-		var whom = $('#'+which+'_select option:selected').text();
-		var action = which + '/' + $('#'+which+'_select option:selected').val();
+$('.btn').filter('[id^="delete-"]').click( function(event) {
+	var which = $(this).attr('id').replace('delete-', '');
+	var whom = $('#'+which+'_select option:selected').text();
+	var action = which + '/' + $('#'+which+'_select option:selected').val();
 
-		event.stopImmediatePropagation();
-		event.preventDefault();
-		verify_delete(whom,action);
-	}
+	event.stopImmediatePropagation();
+	event.preventDefault();
+	verify_delete(whom,action);
 });
 
 


### PR DESCRIPTION
...s previous fixes:

https://github.com/ci-bonfire/Bonfire/commit/1c9dce733eba19e856c110b484199c04aaa30fed
(clicking user edit button fires delete warning)
https://github.com/ci-bonfire/Bonfire/commit/7f2113a3e511a87f130767bde9b1a2a45f74183e
(Delete Activities button doesn't work)

This has the added benefits of:
- not applying an extra click event to buttons that don't need it
- not performing the check for the id in the click event
- doesn't require the selector to be updated every time someone puts an id on a button that doesn't need a confirm message
