### PR TITLE
fixed issue with breadcrumbs 

### DIFF
--- a/bonfire/application/libraries/template.php
+++ b/bonfire/application/libraries/template.php
@@ -1162,6 +1162,7 @@ function breadcrumb($my_segments=NULL, $wrap=FALSE, $echo=TRUE)
 	} 
 	else 
 	{
+		$segments = $my_segments;
 		$total    = count($my_segments);
 	}
 


### PR DESCRIPTION
when if user-defined breadcrumbs are used there is undefined variable $segments in

$in_admin = (bool) (is_array($segments) && in_array(SITE_AREA, $segments));
