### PR TITLE
Separate asset-combining configuration option

### DIFF
--- a/bonfire/application/config/application.php
+++ b/bonfire/application/config/application.php
@@ -226,7 +226,8 @@ $config['assets.js_closer'] = '});'. "\n";
 	The 'assets.combine' setting tells the Asset library whether
 	files should be combined or not.
 */
-$config['assets.combine'] = FALSE;
+$config['assets.js_combine'] = FALSE;
+$config['assets.css_combine'] = FALSE;
 
 /*
 	The 'assets.encrypt' setting will mask the app structure

--- a/bonfire/application/libraries/assets.php
+++ b/bonfire/application/libraries/assets.php
@@ -280,7 +280,7 @@ class Assets
 		$styles     = self::find_files($styles, 'css', $bypass_inheritance);
 		$mod_styles	= self::find_files(self::$module_styles, 'css', $bypass_inheritance);
 
-		$combine = self::$ci->config->item('assets.combine');
+		$combine = self::$ci->config->item('assets.css_combine');
 
 		// Loop through the styles, spitting out links for each one.
 		if (!$combine)
@@ -713,7 +713,7 @@ class Assets
 		$scripts = self::find_files($scripts, 'js');
 
 		// We either combine the files into one...
-		if ((empty($new_js) || is_array($new_js)) && $list==FALSE && self::$ci->config->item('assets.combine'))
+		if ((empty($new_js) || is_array($new_js)) && $list==FALSE && self::$ci->config->item('assets.js_combine'))
 		{
 			$return = self::combine_js($scripts);
 		}


### PR DESCRIPTION
This separates the asset combining option into one each for CSS and Javascript, giving greater flexibility during and after development.

It also functions as a workaround for #422, as it allows development to take place with the combined CSS in its final location for the purposes of relatively-linked media locations while leaving the JS uncombined.
