### PR TITLE
Customizable Default Admin Contexts for User Roles

### DIFF
--- a/bonfire/application/controllers/admin/home.php
+++ b/bonfire/application/controllers/admin/home.php
@@ -50,10 +50,16 @@ class Home extends Admin_Controller
 	 *
 	 * @return void
 	 */
-	public function index()
-	{
-		redirect(SITE_AREA .'/content');
-	}//end index()
+    public function index()
+    {
+        if (!class_exists('Role_model'))
+        {
+            $this->load->model('roles/role_model');
+        }
+        $user_role = $this->role_model->find((int)$this->current_user->role_id);
+        $default_context = ($user_role !== false && isset($user_role->default_context)) ? $user_role->default_context : '';
+        redirect(SITE_AREA .'/'.(isset($default_context) && !empty($default_context) ? $default_context : 'content'));
+    }//end index()
 
 	//--------------------------------------------------------------------
 

--- a/bonfire/application/core_modules/roles/controllers/settings.php
+++ b/bonfire/application/core_modules/roles/controllers/settings.php
@@ -108,7 +108,9 @@ class Settings extends Admin_Controller
 			}
 		}
 
-		Template::set('toolbar_title', 'Create New Role');
+        Template::set('contexts', list_contexts(true));
+
+        Template::set('toolbar_title', 'Create New Role');
 		Template::set_view('settings/role_form');
 		Template::render();
 
@@ -150,8 +152,9 @@ class Settings extends Admin_Controller
 		}
 
 		Template::set('role', $this->role_model->find($id));
+        Template::set('contexts', list_contexts(true));
 
-		Template::set('toolbar_title', 'Edit Role');
+        Template::set('toolbar_title', 'Edit Role');
 		Template::set_view('settings/role_form');
 		Template::render();
 
@@ -333,7 +336,8 @@ class Settings extends Admin_Controller
 
 		$this->form_validation->set_rules('description', 'lang:bf_description', 'trim|strip_tags|max_length[255]|xss_clean');
 		$this->form_validation->set_rules('login_destination', 'lang:role_login_destination', 'trim|strip_tags|max_length[255]|xss_clean');
-		$this->form_validation->set_rules('default', 'lang:role_default_role', 'trim|strip_tags|is_numeric|max_length[1]|xss_clean');
+        $this->form_validation->set_rules('default_context', 'lang:role_default_context', 'trim|strip_tags|xss_clean');
+        $this->form_validation->set_rules('default', 'lang:role_default_role', 'trim|strip_tags|is_numeric|max_length[1]|xss_clean');
 		$this->form_validation->set_rules('can_delete', 'lang:role_can_delete_role', 'trim|strip_tags|is_numeric|max_length[1]|xss_clean');
 
 		$_POST['role_id'] = $id;

--- a/bonfire/application/core_modules/roles/language/english/roles_lang.php
+++ b/bonfire/application/core_modules/roles/language/english/roles_lang.php
@@ -50,6 +50,8 @@ $lang['role_not_used']				= 'Not used';
 
 $lang['role_login_destination']		= 'Login Destination';
 $lang['role_destination_note']		= 'The site URL to redirect to on successful login.';
+$lang['role_default_context']		= 'Default Admin Context';
+$lang['role_default_context_note']	= 'The admin context to load when no context is specified (I.E. http://yoursite.com/admin/)';
 
 $lang['matrix_header']				= 'Permission Matrix';
 $lang['matrix_permission']			= 'Permission';

--- a/bonfire/application/core_modules/roles/views/settings/role_form.php
+++ b/bonfire/application/core_modules/roles/views/settings/role_form.php
@@ -37,6 +37,20 @@
 			</div>
 		</div>
 
+        <div class="control-group">
+            <label class="control-label" for="default_context"><?php echo lang('role_default_context') ?></label>
+            <div class="controls">
+                <select name="default_context" id="default_context">
+                    <?php if (isset($contexts) && is_array($contexts) && count($contexts)):?>
+                    <?php foreach($contexts as $context):?>
+                        <option value="<?php echo $context;?>" <?php echo set_select('default_context', $context, (isset($role) && $role->default_context == $context) ? TRUE : FALSE) ?>><?php echo ucfirst($context) ?></option>
+                        <?php endforeach;?>
+                    <?php endif;?>
+                </select>
+                <span class="help-inline"><?php echo form_error('default_context') ? form_error('default_context') : lang('role_default_context_note'); ?></span>
+            </div>
+        </div>
+
 		<div class="control-group <?php echo form_has_error('default') ? 'error' : ''; ?>">
 			<label class="control-label"><?php echo lang('role_default_role')?></label>
 			<div class="controls">

--- a/bonfire/application/db/migrations/core/032_Role_default_context_setting.php
+++ b/bonfire/application/db/migrations/core/032_Role_default_context_setting.php
@@ -1,0 +1,46 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_Role_default_context_setting extends Migration
+{
+
+	/**
+	 * Add a new column to the roles table to create the default context field. Update existing roles with the
+     * default value as well.
+	 */
+	public function up()
+	{
+		$prefix = $this->db->dbprefix;
+
+        $this->dbforge->add_column('roles', array(
+            'default_context'	=> array(
+                'type'			=> 'varchar',
+                'constraint'	=> 255,
+                'default'		=> 'content',
+                'after'         => 'login_destination'
+            )
+        ));
+        $update_roles = "
+			UPDATE `{$prefix}roles` SET `default_context` = 'content';";
+
+		if ($this->db->query($update_roles))
+		{
+			return TRUE;
+		}
+
+	}
+
+	//--------------------------------------------------------------------
+
+	public function down()
+	{
+		$prefix = $this->db->dbprefix;
+
+		// remove the default_context column
+        $this->dbforge->drop_column("roles","default_context");
+
+
+    }
+
+	//--------------------------------------------------------------------
+
+}

--- a/bonfire/application/helpers/application_helper.php
+++ b/bonfire/application/helpers/application_helper.php
@@ -548,3 +548,50 @@ if ( !function_exists('iif') )
 		}
 	}//end iif()
 }
+//--------------------------------------------------------------------
+
+if ( !function_exists('list_contexts') )
+{
+    /**
+     * 	Returns a list of the contexts specified for the application. The options $landing_page_filter
+     * can be applied to force return of contexts that have a landing page (index.php) available.
+     *
+     *	@param	$landing_page_filter	Boolean		TRUE to filter FALSE for all
+     *	@return 						array	The context values array
+     */
+    function list_contexts($landing_page_filter = false)
+    {
+        $ci = &get_instance();
+
+        $contexts = $ci->config->item('contexts');
+        if (empty($contexts) || !is_array($contexts) || !count($contexts))
+        {
+            return false;
+        }
+
+        // Ensure settings context exists
+        if (!in_array('settings', $contexts))
+        {
+            array_push($contexts, 'settings');
+        }
+
+        // Ensure developer context exists
+        if (!in_array('developer', $contexts))
+        {
+            array_push($contexts, 'developer');
+        }
+        // Optional removal of contexts without landing pages
+        if ($landing_page_filter === true)
+        {
+            while ($context = current($contexts))
+            {
+                if (!file_exists(realpath(VIEWPATH).DIRECTORY_SEPARATOR.SITE_AREA.DIRECTORY_SEPARATOR.$context.DIRECTORY_SEPARATOR.'index.php'))
+                {
+                    array_splice($contexts, key($contexts), 1);
+                }
+                next($contexts);
+            }
+        }
+        return $contexts;
+    }
+}


### PR DESCRIPTION
This update directs users entering the admin dashboard to view a default context landing page first instead of the hard coded content target by assigning a default context in each roles settings. I did want to give site admins a choice in assigning a context to show by default when users click to enter the Admin Area.

This is separate from a login destination in that this landing page that would get hit specifically when the controllers/home.php (Admin home controller) index function is hit. So while it is similar to login destination, it actually affects the user taking a different action in the site, entering the dashboard.
