### PR TITLE
Modify timezone_menu to accept optional 4th param

### DIFF
--- a/bonfire/application/core_modules/users/views/settings/user_form.php
+++ b/bonfire/application/core_modules/users/views/settings/user_form.php
@@ -83,7 +83,7 @@
 		<div class="control-group <?php echo form_error('timezone') ? 'error' : '' ?>">
 			<label class="control-label" for="timezones"><?php echo lang('bf_timezone') ?></label>
 			<div class="controls">
-				<?php echo timezone_menu(set_value('timezones', isset($user) ? $user->timezone : $current_user->timezone)); ?>
+				<?php echo timezone_menu(set_value('timezones', isset($user) ? $user->timezone : $current_user->timezone), '', 'timezones', array('id' => 'timezones')); ?>
 				<?php if (form_error('timezones')) echo '<span class="help-inline">'. form_error('timezones') .'</span>'; ?>
 			</div>
 		</div>

--- a/bonfire/application/core_modules/users/views/users/profile.php
+++ b/bonfire/application/core_modules/users/views/users/profile.php
@@ -102,7 +102,7 @@
 		<div class="control-group <?php echo form_error('timezone') ? 'error' : '' ?>">
 			<label class="control-label required" for="timezones"><?php echo lang('bf_timezone') ?></label>
 			<div class="controls">
-				<?php echo timezone_menu(set_value('timezones', isset($user) ? $user->timezone : $current_user->timezone)); ?>
+				<?php echo timezone_menu(set_value('timezones', isset($user) ? $user->timezone : $current_user->timezone), '', 'timezones', array('id' => 'timezones')); ?>
 				<?php if (form_error('timezones')) echo '<span class="help-inline">'. form_error('timezones') .'</span>'; ?>
 			</div>
 		</div>

--- a/bonfire/application/core_modules/users/views/users/register.php
+++ b/bonfire/application/core_modules/users/views/users/register.php
@@ -91,7 +91,7 @@
 		<div class="control-group <?php echo form_error('timezone') ? 'error' : '' ?>">
 			<label class="control-label required" for="timezones"><?php echo lang('bf_timezone') ?></label>
 			<div class="controls">
-				<?php echo timezone_menu(set_value('timezones')); ?>
+				<?php echo timezone_menu(set_value('timezones'), '', 'timezones', array('id' => 'timezones')); ?>
 				<?php if (form_error('timezones')) echo '<span class="help-inline">'. form_error('timezones') .'</span>'; ?>
 			</div>
 		</div>

--- a/bonfire/codeigniter/helpers/date_helper.php
+++ b/bonfire/codeigniter/helpers/date_helper.php
@@ -499,11 +499,12 @@ if ( ! function_exists('human_to_unix'))
  * @param	string	timezone
  * @param	string	classname
  * @param	string	menu name
+ * @param	mixed	attributes
  * @return	string
  */
 if ( ! function_exists('timezone_menu'))
 {
-	function timezone_menu($default = 'UTC', $class = "", $name = 'timezones')
+	function timezone_menu($default = 'UTC', $class = "", $name = 'timezones', $attributes = '')
 	{
 		$CI =& get_instance();
 		$CI->lang->load('date');
@@ -518,7 +519,21 @@ if ( ! function_exists('timezone_menu'))
 			$menu .= ' class="'.$class.'"';
 		}
 
-		$menu .= ">\n";
+		// Generate a string from the attributes submitted, if any
+		if (is_array($attributes))
+		{
+			$atts = '';
+			foreach ($attributes as $key => $val)
+			{
+				$atts .= ' '.$key.'="'.$val.'"';
+			}
+			$attributes = $atts;
+		}
+		elseif (is_string($attributes) && strlen($attributes) > 0)
+		{
+			$attributes = ' '.$attributes;
+		}
+		$menu .= $attributes.">\n";
 
 		foreach (timezones() as $key => $val)
 		{


### PR DESCRIPTION
to allow setting one or more attributes on the generated select tag.
This allows passing attributes needed for Section 508 compliance §
1194.22(n), such as an id.
http://access-board.gov/sec508/guide/1194.22.htm#(n)
http://www.w3.org/TR/WCAG10-HTML-TECHS/#forms-labels

Ported from CodeIgniter pull request:
https://github.com/EllisLab/CodeIgniter/pull/1519
