### PR TITLE
adding TIME type to array of field types where value/length isn't possible

### DIFF
--- a/bonfire/application/core_modules/modulebuilder/views/files/db_migration.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/db_migration.php
@@ -1,7 +1,7 @@
 <?php
 
  // There are no doubt more types where a value/length isn't possible - needs investigating
-$no_length = array('TEXT', 'BOOL', 'DATE', 'DATETIME', 'TIMESTAMP', 'BLOB', 'TINYBLOB', 'TINYTEXT', 'MEDIUMBLOB', 'MEDIUMTEXT', 'LONGBLOB', 'LONGTEXT');
+$no_length = array('TEXT', 'BOOL', 'DATE', 'DATETIME', 'TIME', 'TIMESTAMP', 'BLOB', 'TINYBLOB', 'TINYTEXT', 'MEDIUMBLOB', 'MEDIUMTEXT', 'LONGBLOB', 'LONGTEXT');
 
 if(!$table_as_field_prefix)
 {


### PR DESCRIPTION
Creating a module will throw a database error because it will try to set a length to the TIME field, like:
"Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '() NOT NULL"
