### PR TITLE
Replace minified asset files in add_js/add_css calls with the non-minified versions

### DIFF
--- a/bonfire/application/core_modules/activities/controllers/reports.php
+++ b/bonfire/application/core_modules/activities/controllers/reports.php
@@ -45,17 +45,17 @@ class Reports extends Admin_Controller
 		$this->auth->restrict('Bonfire.Activities.View');
 
 		$this->lang->load('activities');
-		$this->lang->load('datatable');		
+		$this->lang->load('datatable');
 
 		Template::set('toolbar_title', lang('activity_title'));
 
 		Assets::add_js(Template::theme_url('js/bootstrap.js'));
 		Assets::add_js($this->load->view('reports/activities_js', null, true), 'inline');
 
-		Assets::add_js( array ( Template::theme_url('js/jquery.dataTables.min.js' )) );
+		Assets::add_js( array ( Template::theme_url('js/jquery.dataTables.js' )) );
 		Assets::add_js( array ( Template::theme_url('js/bootstrap-dataTables.js' )) );
 		Assets::add_css( array ( Template::theme_url('css/datatable.css') ) ) ;
-		Assets::add_css( array ( Template::theme_url('css/bootstrap-dataTables.css') ) ) ;		
+		Assets::add_css( array ( Template::theme_url('css/bootstrap-dataTables.css') ) ) ;
 
 
 		//Assets::add_module_css ('activities', 'datatables.css');

--- a/bonfire/application/core_modules/modulebuilder/views/files/controller.php
+++ b/bonfire/application/core_modules/modulebuilder/views/files/controller.php
@@ -372,7 +372,7 @@ for($counter=1; $field_total >= $counter; $counter++)
 		{
 			$extras .= '
 			Assets::add_css(\'flick/jquery-ui-1.8.13.custom.css\');
-			Assets::add_js(\'jquery-ui-1.8.13.min.js\');';
+			Assets::add_js(\'jquery-ui-1.8.13.js\');';
 			$date_included = TRUE;
 		}
 		elseif ($db_field_type == 'DATETIME' && $datetime_included === FALSE)
@@ -382,7 +382,7 @@ for($counter=1; $field_total >= $counter; $counter++)
 			{
 				$extras .= '
 			Assets::add_css(\'flick/jquery-ui-1.8.13.custom.css\');
-			Assets::add_js(\'jquery-ui-1.8.13.min.js\');';
+			Assets::add_js(\'jquery-ui-1.8.13.js\');';
 			}
 			$extras .= '
 			Assets::add_css(\'jquery-ui-timepicker.css\');
@@ -504,7 +504,7 @@ if ($controller_name != $module_name_lower)
 
 		// we set this variable as it will be used to place the comma after the last item to build the insert db array
 		$last_field = $counter;
-            
+
 		if($db_required == 'new' && $table_as_field_prefix === TRUE)
 		{
 				$field_name = $module_name_lower . '_' . set_value("view_field_name$counter");
@@ -513,7 +513,7 @@ if ($controller_name != $module_name_lower)
 		{
 				$field_name = set_value("view_field_name$counter");
 		}
-		else 
+		else
 		{
 				$field_name = set_value("view_field_name$counter");
 		}

--- a/bonfire/themes/admin/index.php
+++ b/bonfire/themes/admin/index.php
@@ -1,5 +1,5 @@
 <?php
-	Assets::add_js( array( 'bootstrap.min.js', 'jwerty.js'), 'external', true);
+	Assets::add_js( array( 'bootstrap.js', 'jwerty.js'), 'external', true);
 ?>
 <?php echo theme_view('partials/_header'); ?>
 

--- a/bonfire/themes/admin/two_left.php
+++ b/bonfire/themes/admin/two_left.php
@@ -1,6 +1,6 @@
 <?php
 Assets::add_js(array(
-                    Template::theme_url('js/bootstrap.min.js'),
+                    Template::theme_url('js/bootstrap.js'),
                     Template::theme_url('js/jwerty.js')
                ),
                'external',

--- a/bonfire/themes/default/parts/_header.php
+++ b/bonfire/themes/default/parts/_header.php
@@ -1,8 +1,8 @@
 <?php
 	// Setup our default assets to load.
-	Assets::add_js( 'bootstrap.min.js' );
-	Assets::add_css( array('bootstrap.min.css', 'bootstrap-responsive.min.css'));
-			
+	Assets::add_js( 'bootstrap.js' );
+	Assets::add_css( array('bootstrap.css', 'bootstrap-responsive.css'));
+
 	$inline  = '$(".dropdown-toggle").dropdown();';
 	$inline .= '$(".tooltips").tooltip();';
 	$inline .= '$(".login-btn").click(function(e){ e.preventDefault(); $("#modal-login").modal(); });';


### PR DESCRIPTION
This should allow the assets library to determine whether or not the minified versions are loaded based on the current configuration. The base jQuery library is not usually loaded through the assets library, though, so I did not change references to it.

Fixes an issue where bootstrap.js and bootstrap.min.js are both loaded on certain pages if minified assets are not enabled.

If needed, I can also add the non-minified files to some of the locations, although I do _not_ have a clean non-minified version of bootstrap-responsive.css for v2.0.3 (the file in the Bonfire folders appears to be v2.0.2).
