### PR TITLE
fixed language file reference for reset password

### DIFF
--- a/bonfire/application/core_modules/users/controllers/users.php
+++ b/bonfire/application/core_modules/users/controllers/users.php
@@ -190,7 +190,7 @@ class Users extends Front_Controller
 
 						$data = array(
 									'to'	=> $_POST['email'],
-									'subject'	=> lang('us_reset_password_email_subject'),
+									'subject'	=> lang('us_reset_pass_subject'),
 									'message'	=> $this->load->view('_emails/forgot_password', array('link' => $pass_link), TRUE)
 							 );
 


### PR DESCRIPTION
The reference to lang('us_reset_password_email_subject') was causing the reset password form to not work. In the language file, the reference is us_reset_pass_subject.

Simple fix :)
