### PR TITLE
Un-break session for users behind load-balanced proxies, e.g. AOL

### DIFF
--- a/bonfire/application/config/config.php
+++ b/bonfire/application/config/config.php
@@ -256,7 +256,7 @@ $config['sess_expire_on_close']	= FALSE;
 $config['sess_encrypt_cookie']	= FALSE;
 $config['sess_use_database']	= FALSE;
 $config['sess_table_name']		= 'sessions';
-$config['sess_match_ip']		= TRUE;
+$config['sess_match_ip']		= FALSE;
 $config['sess_match_useragent']	= TRUE;
 $config['sess_time_to_update']	= 300;
 


### PR DESCRIPTION
sess_match_ip: "Whether to match the user's IP address when reading
the session data. Note that some ISPs dynamically changes the IP,
so if you want a non-expiring session you will likely set this to FALSE."

which was the default in CodeIgniter.

http://codeigniter.com/user_guide/libraries/sessions.html

The internet says that AOL is known to be affected.
With sess_match_ip = TRUE, the admin interface
could be completely unusable on affected networks.

Forcing all users to use a proxy is common on slower links.
I noticed it on our BT dialup.  I would not be at all surprised
to see it on cell-phone or satellite connections.

Signed-off-by: Alan Jenkins alan.christopher.jenkins@gmail.com
