### PR TITLE
"Modal" login box: two small fixes to password reset

### DIFF
--- a/bonfire/themes/default/parts/modal_login.php
+++ b/bonfire/themes/default/parts/modal_login.php
@@ -50,7 +50,7 @@
 				No account? <a href="<?php echo site_url('register') ?>"><?php echo lang('bf_action_register'); ?>!</a> |
 			<?php endif; ?>
 
-			<a href=""><?php echo lang('bf_forgot_password'); ?></a>
+			<?php echo anchor('/forgot_password', lang('bf_forgot_password')); ?>
 		</p>
 	</div>
 


### PR DESCRIPTION
The password reset link didn't work (and would sometimes not be shown).  I looking at what the main login page did, and fixed the modal one accordingly.
