### PR TITLE
Line 272: chmod() $folder instead of the full path $full_folder 

### DIFF
--- a/install/controllers/install.php
+++ b/install/controllers/install.php
@@ -269,7 +269,7 @@ class Install extends CI_Controller {
 		{
 			$full_folder = FCPATH . '..' . $folder;
 
-			@chmod($folder, 0777);
+			@chmod($full_folder, 0777);
 			if (!is_dir($full_folder) || !is_writeable($full_folder))
 			{
 				$folder_errors .= "<li>$folder</li>";


### PR DESCRIPTION
Line 270: Retrieve full path of folder in $full_folder 
Line 272: chmod() $folder instead of the full path $full_folder

Changed line 272 to chmod() $full_folder as it was giving errors.
