### PR TITLE
Assets library outputs duplicates

### DIFF
--- a/bonfire/application/libraries/assets.php
+++ b/bonfire/application/libraries/assets.php
@@ -1356,7 +1356,12 @@ class Assets
 						echo '</ul>' . PHP_EOL;
 					}
 
-					if (!$bypass_inheritance)
+					/*
+					 * If default_theme and active_theme are the same,
+					 * checking the default_theme would just repeat the
+					 * active_theme section below, resulting in duplicates
+					 */
+					if (!$bypass_inheritance && $default_theme !== $active_theme)
 					{
 						/*
 							DEFAULT THEME


### PR DESCRIPTION
When outputting a single file, if the default and active theme are the same and inheritance is not bypassed, the assets library will link the same file twice.
Specifically this problem occurrs when outputting a CSS file in a view calling
echo Assets::css('some.css');
