### PR TITLE
Alternative solution to "issue with the CSRF for Ajax testing of Email"

### DIFF
--- a/bonfire/application/core_modules/emailer/assets/js/settings.js
+++ b/bonfire/application/core_modules/emailer/assets/js/settings.js
@@ -25,16 +25,17 @@ $(document).ready(function(){
 	$('#test-form').submit(function(e){
 		e.preventDefault();
 
-		var email	= $('#test-email').val();
-		var url		= $(this).attr('action');
-        var csrf_test_name = $('input[name=csrf_test_name]').val();
+		// Grab all the form data, including the CodeIgniter anti-CSRF token
+		var data    = $(this).serialize();
 
-		$('#test-ajax').load(
+		// Submit the form by AJAX, and display the result.
+		var url		= $(this).attr('action');
+
+		$.post(
 			url,
-			{
-				email: email,
-				url: url,
-                csrf_test_name: csrf_test_name
+			data,
+			function success(data) {
+				$('#test-ajax').html(data);
 			}
 		);
 	});

--- a/bonfire/application/core_modules/emailer/views/settings/index.php
+++ b/bonfire/application/core_modules/emailer/views/settings/index.php
@@ -117,7 +117,7 @@
 			<div class="control-group">
 				<label class="control-label" for="test-email"><?php echo lang('bf_email'); ?></label>
 				<div class="controls">
-					<input type="email" name="test_email" id="test-email" value="<?php echo set_value('test_email', settings_item('site.system_email')) ?>" />
+					<input type="email" name="email" id="test-email" value="<?php echo set_value('test_email', settings_item('site.system_email')) ?>" />
 					<input type="submit" name="submit" class="btn btn-primary" value="<?php echo lang('em_test_button'); ?>" />
 				</div>
 			</div>


### PR DESCRIPTION
Current solution looks perfectly correct.  I just found a "cleaner"-looking alternative, using serialize() on the whole form.
