### PR TITLE
Error attempting to use auth->role_name_by_id()

### DIFF
--- a/bonfire/application/core_modules/users/libraries/auth.php
+++ b/bonfire/application/core_modules/users/libraries/auth.php
@@ -583,6 +583,10 @@ class Auth
 		}
 		else
 		{
+			if (! class_exists('Role_model'))
+			{
+				$this->ci->load->model('roles/role_model');
+			}
 			$results = $this->ci->role_model->select('role_id, role_name')->find_all();
 
 			foreach ($results as $role)


### PR DESCRIPTION
When attempting to use auth->role_name_by_id(), the library throws an
error, attempting to call method select on a non-object. Fixed by
checking to see if the Role_model class exists and, if not, loading it.

Note: line-endings in the repository appear to be CR/LF for this file, so the diff is a mess. The only lines changed should be the addition of lines 586-589.
