### PR TITLE
Make find_by/find_all_by more consistent

### DIFF
--- a/bonfire/application/core/MY_Model.php
+++ b/bonfire/application/core/MY_Model.php
@@ -293,20 +293,18 @@ class BF_Model extends CI_Model
 		if (empty($field)) return FALSE;
 
 		// Setup our field/value check
-		if (is_array($field))
+		if ( ! is_array($field))
 		{
-			if ($type == 'or')
-			{
-				$this->db->or_where($field);
-			}
-			else
-			{
-				$this->db->where($field);
-			}
+			$field = array($field => $value);
+		}
+
+		if ($type == 'or')
+		{
+			$this->db->or_where($field);
 		}
 		else
 		{
-			$this->db->where($field, $value);
+			$this->db->where($field);
 		}
 
 		$this->set_selects();
@@ -336,20 +334,18 @@ class BF_Model extends CI_Model
 			return FALSE;
 		}
 
-		if (is_array($field))
+		if ( ! is_array($field))
 		{
-			if ($type == 'or')
-			{
-				$this->db->or_where($field);
-			}
-			else
-			{
-				$this->db->where($field);
-			}
+			$field = array($field => $value);
+		}
+
+		if ($type == 'or')
+		{
+			$this->db->or_where($field);
 		}
 		else
 		{
-			$this->db->where($field, $value);
+			$this->db->where($field);
 		}
 
 		$this->set_selects();


### PR DESCRIPTION
cast $field/$value pair into an array (if $field is not an array),
check $type and call or_where/where accordingly, always passing an array
