### PR TITLE
Allow page title to be set on the front-end

### DIFF
--- a/bonfire/themes/default/parts/head.php
+++ b/bonfire/themes/default/parts/head.php
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title><?php e($this->settings_lib->item('site.title')); ?></title>
+    <title><?php echo isset($page_title) ? $page_title .' : ' : ''; ?> <?php e($this->settings_lib->item('site.title')); ?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">


### PR DESCRIPTION
Admin pages customize title by setting `$toolbar_title`.  The front-end pages in the user module try to set `$page_title`, but that doesn't do anything.  Front-end pages _should_ be able to set the title appropriately.  (Otherwise they won't be conforming to HTML :).

Is $page_title a sensible variable name? Will the same format be ok?  `"$page_title : {$this->settings_lib->item('site.title')}"`

The values used by the user module for $page_title are 'Login', 'Password Reset', 'Register', 'Account Activation', 'Activate Account'.  (Not translated).
