### PR TITLE
Fix error (notice) undefined index on role update

### DIFF
--- a/bonfire/application/core_modules/permissions/models/permission_model.php
+++ b/bonfire/application/core_modules/permissions/models/permission_model.php
@@ -178,7 +178,7 @@ class Permission_model extends BF_Model
 	{
 		$updated = parent::update($id, $data);
 
-		if ($data['status'] == 'inactive' && $updated === TRUE)
+		if (isset($data['status']) && $data['status'] == 'inactive' && $updated === TRUE)
 		{
 			// now delete the role_permissions for this permission since it is no longer active
 			$updated = $this->role_permission_model->delete_for_permission($id);


### PR DESCRIPTION
When updating a role the system briefly displays a PHP error and logs:
ERROR - 2012-09-27 20:44:59 --> Severity: Notice --> Undefined index:
status
C:\Users\mwhitney\apache\webroot\bonfire\application\core_modules\permissions\models\permission_model.php
181

Traced it back to
/application/core_modules/roles/controllers/settings.php line 359, where
the roles controller attempts to update permissions with a call to
update_where().

Since it's conceivable someone might want to update a permission without
changing its status, it should be ok to call update without
$data['status'] being set.
