### PR TITLE
Issue #613 - Add quotation marks to migration files for Enum and Set

### DIFF
--- a/bonfire/application/core_modules/builder/views/files/db_migration.php
+++ b/bonfire/application/core_modules/builder/views/files/db_migration.php
@@ -45,7 +45,14 @@ class Migration_Install_'.$table_name.' extends Migration {
 
 		if (!in_array(set_value("db_field_type$counter"), $no_length))
 		{
-			$escaped_constraint_val = addcslashes($this->input->post("db_field_length_value$counter"),'"');
+            // ENUM or SET
+            if (in_array(set_value("db_field_type$counter"), array("ENUM", "SET"))){
+                  $escaped_constraint_val = '"' . addcslashes($this->input->post("db_field_length_value$counter"),'"') . '"';
+            }
+            
+            else {
+                $escaped_constraint_val = addcslashes($this->input->post("db_field_length_value$counter"),'"');    
+            }
 
 			if (in_array(set_value("db_field_type$counter"), $optional_length) && empty($escaped_constraint_val) && !is_numeric($escaped_constraint_val))
 			{


### PR DESCRIPTION
The existing code generates SQL which causes a database error, at least
for MySQL v 5.5.25. Something like:
CREATE TABLE bf_todo ( id INT(11) NOT NULL AUTO_INCREMENT,
todo_selectme ENUM(a) NOT NULL, PRIMARY KEY id (id) ) DEFAULT CHARACTER
SET utf8 COLLATE utf8_general_ci;

Note the "ENUM(a)" which is incorrect.

The modified code in this commit generates SQL which includes
"ENUM('a','b','c')", which works.
