### PR TITLE
when you try to run the site for the first time and just use the domain ...

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,8 +3,9 @@
 // Check if the install folder exists - if so then show the installer app
 if (is_dir(dirname(__FILE__).'/install') == true)
 {
+	$host  = $_SERVER['HTTP_HOST'];
 	$dir = dirname($_SERVER['SCRIPT_NAME']);
-	header("Location: {$dir}/install");
+	header("Location: http://$host/install");
 	exit;
 }
 


### PR DESCRIPTION
...name (i.e. http://domain.com) instead of using (http://domain.com/install) the redirection to the install folder fails. this fixes that.
