### PR TITLE
Modify images controller to search in assets/images/subdirectories if fi...

### DIFF
--- a/bonfire/application/controllers/images.php
+++ b/bonfire/application/controllers/images.php
@@ -102,13 +102,13 @@ class Images extends Base_Controller {
 			// Try all subdirectories
 			$dirs = array_filter(glob($assets . '/*'), 'is_dir');
 			foreach($dirs as $d){
-				if ( !empty($img_found) && is_file(FCPATH . $d . '/' . $file)) {
+				if ( empty($img_found) && is_file(FCPATH . $d . '/' . $file)) {
 					$img_file = FCPATH . $d . '/' . $file; 
 					$img_found = true;
 				}
 			}
 			
-			if (!empty($img_found)) { die('Image could not be found.'); }
+			if (empty($img_found)) { die('Image could not be found.'); }
 		}
 
 		$new_file = FCPATH .'assets/cache/'. str_replace('.'. $ext, '', $file) ."_{$width}x{$height}.". $ext;


### PR DESCRIPTION
Not sure if you guys want to include this but it helps me...

Use case:
- I store my images in subfolders under /assets/images
- instead of typing URLs like /images/myimage.png?assets=assets/images/common I modified the images controller to automatically search the subdirectories so that I can just type /images/myimage.png
