### PR TITLE
Translation for french,  add "lang()" having been omitted and new entry for breadcrumb language

### DIFF
--- a/bonfire/application/core_modules/activities/config/config.php
+++ b/bonfire/application/core_modules/activities/config/config.php
@@ -1,7 +1,7 @@
 <?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 $config['module_config'] = array(
-	'description'	=> 'Allows other modules to store user activity information.',
+	'description'	=> 'Permet de voir les informations sur l\'activité des utilisateurs.',
 	'author'		=> 'Bonfire Team',
-	'name'			=> 'Activities'
+	'name'			=> 'Activitiés'
 );

--- a/bonfire/application/core_modules/activities/controllers/reports.php
+++ b/bonfire/application/core_modules/activities/controllers/reports.php
@@ -324,8 +324,8 @@ class Reports extends Admin_Controller
 		Template::set('filter', $this->input->post($which.'_select'));
 
 		// set a couple default variables
-		$options = array('all' => 'All');
-		$name = 'All';
+		$options = array('all' => lang('activity_all'));
+		$name = lang('activity_all');
 
 		switch ($which)
 		{

--- a/bonfire/application/core_modules/activities/language/english/activities_lang.php
+++ b/bonfire/application/core_modules/activities/language/english/activities_lang.php
@@ -21,6 +21,7 @@
 	THE SOFTWARE.
 */
 
+$lang['activities']						= 'Activities';
 $lang['activity_home']					= 'Home';
 $lang['activity_title']					= 'Site Activities';
 $lang['activity_own']					= 'Your';
@@ -68,3 +69,7 @@ $lang['activity_no_top_modules']		= "No module activity records found.";
 $lang['activity_no_top_users']			= "No user activity records found.";
 $lang['activity_logged']				= "Activities Logged";
 $lang['activity_none_found']			= 'You do not have permissions to delete any activities.';
+$lang['activity_from_before']			= 'from before';
+$lang['activity_only_for']				= 'only for';
+$lang['activity_all']					= 'All';
+$lang['activity_cleanup']				= 'Activity Cleanup';

--- a/bonfire/application/core_modules/activities/language/french/activities_lang.php
+++ b/bonfire/application/core_modules/activities/language/french/activities_lang.php
@@ -1,0 +1,76 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+	Copyright (c) 2011 Lonnie Ezell
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+$lang['activities']						= 'Activités';
+$lang['activity_home']					= 'Accueil';
+$lang['activity_title']					= 'Activités du site';
+$lang['activity_own']					= 'Votre activité';
+$lang['activity_user']					= 'Utilisateur';
+$lang['activity_users']					= 'Utilisateurs';
+$lang['activity_module']				= 'Module';
+$lang['activity_modules']				= 'Modules';
+$lang['activity_date']					= 'Date';
+$lang['activity_activity']				= 'Activités';
+$lang['activity_not_found']				= 'Aucune activités trouvées.';
+$lang['activity_when']					= 'Performed';
+$lang['activity_all_users']				= 'Tous les utilisateurs';
+$lang['activity_all_modules']			= 'Tous les Modules';
+$lang['activity_core']					= 'Bonfire core';
+$lang['activity_all_dates']				= 'Nimporte quand';
+$lang['activity_filter']				= 'Filtre';
+$lang['activity_filter_head']			= 'Filtre d\'activité.';
+$lang['activity_filter_note']			= 'Voir les activités %s%s sélectionné(e).';
+$lang['activity_view']					= 'Voir %s: <b>%s</b>';
+$lang['activity_delete_own_confirm'] 	= "Êtes vous certain de vouloir supprimer les enregistrements de votre activité ?";
+$lang['activity_delete_user_confirm'] 	= "Êtes vous certain de vouloir supprimer les enregistrements de l'utilisateur sélectionné ?";
+$lang['activity_delete_module_confirm'] = "Êtes vous certain de vouloir supprimer les enregistrements du module sélectionné ?";
+$lang['activity_delete_date_confirm'] 	= "Êtes vous certain de vouloir supprimer les enregistrements de la date sélectionnée ?";
+$lang['activity_own_delete']			= "Supprimer vos activités";
+$lang['activity_user_delete']			= "Supprimer l'activité de l'utilisateur";
+$lang['activity_module_delete']			= "Supprimer l'activité du module";
+$lang['activity_date_delete']			= "Supprimer l'activité des dates";
+$lang['activity_delete_own_note']		= "Supprimer votre journal d\'activité' : ";
+$lang['activity_delete_user_note']		= "Supprimer le journal d\'activité de : ";
+$lang['activity_delete_module_note']	= "Supprimer le journal d\'activité du module : ";
+$lang['activity_delete_date_note']		= "Supprimer le journal d\'activité depuis le  : ";
+$lang['activity_own_description']		= "Vos activités.";
+$lang['activity_users_description']		= "Activités par Utilisateurs.";
+$lang['activity_module_description']	= "Activités par Module.";
+$lang['activity_date_description']		= "Activités par Date.";
+$lang['activity_delete_record']			= "Supprimer les enregistrements d'activité";
+$lang['activity_delete_confirm']		= "Êtes-vous certain ?";
+$lang['activity_delete_warning']		= "Ceci supprimera tous les journaux d'activités";
+$lang['activity_restricted']			= "Autorisation requise. Désolé, vous n'avez pas les droits nécéssaires pour effectuer cette tâche.";
+$lang['activity_nothing']				= "0 enregistrements trouvés. Rien à supprimer.";
+$lang['activity_deleted']				= "%d enregistrements supprimés.";
+$lang['activity_top_modules']			= "Top 5 des Modules activés";
+$lang['activity_top_users']				= "Top 5 des Utilisateurs activés";
+$lang['activity_no_top_modules']		= "Aucun enregistrement d'activité des modules trouvé.";
+$lang['activity_no_top_users']			= "Aucun enregistrements d'activités des utilisateurs trouvés.";
+$lang['activity_logged']				= "Activités enregistrées";
+$lang['activity_none_found']			= 'Vous n\'avez pas les droits nécéssaires pour supprimer les journaux d\'activités.';
+$lang['activity_from_before']			= 'de la ';
+$lang['activity_only_for']				= 'du ';
+$lang['activity_only_for_except_1']		= 'de l\'';
+$lang['activity_all']					= 'Tous';
+$lang['activity_cleanup']				= 'Netoyage des Activités enregistrées';

--- a/bonfire/application/core_modules/activities/views/reports/index.php
+++ b/bonfire/application/core_modules/activities/views/reports/index.php
@@ -95,7 +95,7 @@
 				<table class="table table-striped">
 					<thead>
 						<tr>
-							<th><?php echo lang('activity_module'); ?></th>
+							<th><?php echo lang('activity_user'); ?></th>
 							<th><?php echo lang('activity_logged'); ?></th>
 						</tr>
 					</thead>
@@ -118,7 +118,7 @@
 
 
 <div class="admin-box">
-	<h3>Activity Cleanup</h3>
+	<h3><?php echo lang('activity_cleanup'); ?></h3>
 
 	<?php $empty_table = true; ?>
 

--- a/bonfire/application/core_modules/activities/views/reports/view.php
+++ b/bonfire/application/core_modules/activities/views/reports/view.php
@@ -3,7 +3,13 @@
 		<?php
 			echo form_open(SITE_AREA . '/reports/activities/' . $vars['which'], 'class="form-horizontal constrained"');
 
-			$form_help = '<span class="help-inline">' . sprintf(lang('activity_filter_note'),($vars['view_which'] == ucwords(lang('activity_date')) ? 'from before':'only for'),strtolower($vars['view_which'])) . '</span>';
+			$config =& get_config();
+			if($config['language'] == 'french'){
+				if($vars['which'] == 'activity_module') $special_lang_only_for = lang('activity_only_for');
+				elseif($vars['which'] == 'activity_user') $special_lang_only_for = lang('activity_only_for_except_1');
+				elseif($vars['which'] == 'activity_date') $special_lang_only_for = lang('activity_only_for');
+				$form_help = '<span class="help-inline">' . sprintf(lang('activity_filter_note'),($vars['view_which'] == ucwords(lang('activity_date')) ? lang('activity_from_before'):$special_lang_only_for),strtolower($vars['view_which'])) . '</span>';
+			}else $form_help = '<span class="help-inline">' . sprintf(lang('activity_filter_note'),($vars['view_which'] == ucwords(lang('activity_date')) ? lang('activity_from_before'):lang('activity_only_for')),strtolower($vars['view_which'])) . '</span>';
 			$form_data = array('name' => $vars['which'].'_select', 'id' => $vars['which'].'_select', 'class' => 'span3' );
 			echo form_dropdown($form_data, $select_options, $filter, lang('activity_filter_head') , '' , $form_help);
 			//echo form_dropdown("activity_select", $select_options, $filter,array('id' => 'activity_select', 'class' => 'span4' ) );
@@ -26,7 +32,7 @@
 
 	<br/>
 
-	<h2><?php echo sprintf(lang('activity_view'),($vars['view_which'] == ucwords(lang('activity_date')) ? $vars['view_which'] . ' before' : $vars['view_which']),$vars['name']); ?></h2>
+	<h2><?php echo sprintf(lang('activity_view'),($vars['view_which'] == ucwords(lang('activity_date')) ? $vars['view_which'] . ' '.lang('activity_only_for') : $vars['view_which']),$vars['name']); ?></h2>
 
 	<?php if (!isset($activity_content) || empty($activity_content)) : ?>
 	<div class="alert alert-error fade in">

--- a/bonfire/application/core_modules/builder/language/french/builder_lang.php
+++ b/bonfire/application/core_modules/builder/language/french/builder_lang.php
@@ -1,0 +1,133 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+	Copyright (c) 2011 Lonnie Ezell
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+	
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+	
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+// INDEX page
+$lang['mb_create_button']		= 'Créer un Module';
+$lang['mb_create_link']			= 'Créer un nouveau module';
+$lang['mb_create_note']			= 'Utilisez notre assistant pour créer votre prochain module. Nous faisons tout le travail lourd en générant tous les contrôleurs, modèles, vues et les fichiers de langue dont vous aurez besoin.';
+$lang['mb_not_writeable_note']	= 'Erreur: Le répertoire bonfire/modules n\'est pas accessible en écriture donc les modules ne peuvent pas êtres écrits sur le serveur. Merci de vous assurez que le répertoire est accessible en écriture et rafraîchissez cette page.';
+$lang['mb_generic_description']	= 'Votre description ici.';
+$lang['mb_installed_head']		= 'Module de l\'application installés';
+$lang['mb_module']				= 'Module';
+$lang['mb_no_modules']			= 'Aucun module installé.';
+
+$lang['mb_table_name']			= 'Nom';
+$lang['mb_table_version']		= 'Version';
+$lang['mb_table_author']		= 'Auteur';
+$lang['mb_table_description']	= 'Description';
+
+// OUTPUT page
+$lang['mb_out_success']	= 'La création du module a été un succès ! Vous trouvez ci-dessous la liste des fichiers des contrôleurs, modèles et vues qui ont été créeés au cours de ce processus. Les fichiers des modèles et SQL seront inclus si vous avez sélectionné la fonction "Générer les migrations" et un fichier Javascript si il est nécéssaire lors de la création.';
+$lang['mb_out_success_note']	= 'NOTE: Merci d\'ajouter la validations d\'entrées des utilisateurs que vous désirez. Ce code doit petre utilisé comme un point de départ seuleuement.';
+$lang['mb_out_tables_success']	= 'Les tables de la base de données ont été installés automatiquement pour vous. Vous pouvez les vérifier ou les désinstaller si vous le souhaitez, à partir de la section %s.';
+$lang['mb_out_tables_error']	= 'Les tables de la base de données <strong>n\'ont pas été</strong> installé automatiquement pour vous. Vous avez encore besoin d\'aller à la section %s et migrer votre(vos) base(s) de données avant de pouvoir travailler avec.';
+$lang['mb_out_acl'] 			= 'Liste de Contrôle d\'Accès';
+$lang['mb_out_acl_path']        = 'migrations/001_Installation_%s_permissions.php';
+$lang['mb_out_config'] 			= 'Fichier de Config';
+$lang['mb_out_config_path'] 	= 'config/config.php';
+$lang['mb_out_controller']		= 'Contrôlleurs';
+$lang['mb_out_controller_path']	= 'controllers/%s.php';
+$lang['mb_out_model'] 			= 'Modèles';
+$lang['mb_out_model_path']		= '%s_model.php';
+$lang['mb_out_view']			= 'Vues';
+$lang['mb_out_view_path']		= 'views/%s.php';
+$lang['mb_out_lang']			= 'Fichier de Langue';
+$lang['mb_out_lang_path']		= '%s_lang.php';
+$lang['mb_out_migration']		= 'Fichier(s) de Migration';
+$lang['mb_out_migration_path']	= 'migrations/002_Install_%s.php';
+$lang['mb_new_module']			= 'Nouveau Module';
+$lang['mb_exist_modules']		= 'Modules existants';
+
+// FORM page
+$lang['mb_form_note'] = '<p><b>Remplissez les champs que vous souhaitez dans votre module (un champs "id" est créeé automatiquement).  Si vous voulez créer le SQL de la BDD pour une table de la base de donnée, cocher la case "Créer la Table du Module".</b></p><p>Ce formulaire va générer un module Codeigniter complet (modèle, contrôlleur, vues) et, si vous le choisissez, les fichiers de migrations de base de données.</p>';
+
+$lang['mb_table_note'] = '<p>Votre table sera créée avec au moins un champ, le champ clé primaire qui sera utilisé comme identifiant unique et comme un index. Si vous avez besoin de champ supplémentaire, cliquez sur le nombre de champs dont vous aurez besoin afin de les ajouter à ce formulaire.</p>';
+
+$lang['mb_field_note'] = '<p><b>NOTE : POUR TOUS LES CHAMPS</b><br />Si le champs de la BDD est "enum" ou "set", merci d\'entrer la valeur en utilisant ce format : \'a\',\'b\',\'c\'...<br />Si jamais vous avez besoin de mettre une barre oblique ("\") ou un simple apostrophe ("\'") parmsi ces valeurs, faites précéder d\'une barre oblique inverse (par exemple \'\\xyz\' ou \'a\\\'b\').</p>';
+	
+$lang['mb_form_errors']			= 'Merci de corriger les erreurs ci-dessous.';
+$lang['mb_form_mod_details']	= 'Détails du Module ';
+$lang['mb_form_mod_name']		= 'Nom du Module';
+$lang['mb_form_mod_name_ph']	= 'Forums, Blog, ToDo';
+$lang['mb_form_mod_desc']		= 'Description du Module';
+$lang['mb_form_mod_desc_ph']	= 'Une liste des éléments "ToDo"';
+$lang['mb_form_contexts']		= 'Contextes requis';
+$lang['mb_form_public']			= 'Public';
+$lang['mb_form_table_details']	= 'Détails de la table';
+$lang['mb_form_actions']		= 'Action du Contrôlleur';
+$lang['mb_form_primarykey']		= 'Clé Primaire';
+$lang['mb_form_delims']			= 'Séparateurs des entrée de fomulaire';
+$lang['mb_form_err_delims']		= 'Séparateurs des erreurs de fomulaire';
+$lang['mb_form_text_ed']		= 'Éditeur des Textarea';
+$lang['mb_form_soft_deletes']	= 'utiliser Suppression "Légère" ?';
+$lang['mb_form_use_created']	= 'utiliser "Créer" le champ ?';
+$lang['mb_form_use_modified']	= 'utiliser "Modifier" le champ ?';
+$lang['mb_form_created_field']	= '"Created" nom de champ ?';
+$lang['mb_form_modified_field']	= '"Modifier" nom de champ ?';
+$lang['mb_form_generate']		= 'Créer Table du Module';
+$lang['mb_form_role_id']		= 'Donner le rôle d\'accès complet';
+$lang['mb_form_fieldnum']		= 'D\'autres champs de table';
+$lang['mb_form_field_details']	= 'Détails du champ';
+$lang['mb_form_table_name']		= 'Nom de la Table';
+$lang['mb_form_table_name_ph']	= 'Minuscules, sans espace';
+$lang['mb_form_table_as_field_prefix']		= 'Utiliser le nom de la table comme préfixe des champs';
+$lang['mb_form_label']			= 'Label';
+$lang['mb_form_label_ph']		= 'le nom qui sera utilisé sur les pages web';
+$lang['mb_form_fieldname']		= 'Nom (sans espaces)';
+$lang['mb_form_fieldname_ph']	= 'Le nom du champ pour la base de données. Minuscule est préférable.';
+$lang['mb_form_type']			= 'Webpage Input Type';
+$lang['mb_form_length']			= 'Maximum Length <b>-or-</b> Values';
+$lang['mb_form_length_ph']		= '30, 255, 1000, etc...';
+$lang['mb_form_dbtype']			= 'Database Type';
+$lang['mb_form_rules']			= 'Validation Rules';
+$lang['mb_form_rules_limits']	= 'Input Limitations'; 
+$lang['mb_form_required']		= 'Required';
+$lang['mb_form_unique']			= 'Unique';
+$lang['mb_form_trim']			= 'Trim';
+$lang['mb_form_valid_email']	= 'Valid Email';
+$lang['mb_form_is_numeric']		= '0-9';
+$lang['mb_form_alpha']			= 'a-Z';
+$lang['mb_form_alpha_dash']		= 'a-Z, 0-9, and _-';
+$lang['mb_form_alpha_numeric']	= 'a-Z and 0-9';
+$lang['mb_form_add_fld_button'] = 'Add another field';
+$lang['mb_form_show_advanced']	= 'Toggle Advanced Options';
+$lang['mb_form_show_more']		= '...toggle more rules...';
+$lang['mb_form_integer']		= 'Integers';
+$lang['mb_form_is_decimal']		= 'Decimal Numbers';
+$lang['mb_form_is_natural']		= 'Natural Numbers';
+$lang['mb_form_is_natural_no_zero']	= 'Natural, no zeroes';
+$lang['mb_form_valid_ip']		= 'Valid IP';
+$lang['mb_form_valid_base64']	= 'Valid Base64';
+$lang['mb_form_alpha_extra']	= 'AlphaNumerics, underscore, dash, periods and spaces.';
+
+// Activities
+$lang['mb_act_create']	= 'Module crée';
+$lang['mb_act_delete']	= 'Module supprimé';
+
+$lang['mb_create_a_context']	= 'Créé un Contexte';
+$lang['mb_tools']				= 'Outils';
+$lang['mb_mod_builder']			= 'Constructeur de Module';
+$lang['mb_new_context']			= 'Nouveau Contexte';
+$lang['mb_no_context_name']		= 'Nom de Contexte invalide.';
+$lang['mb_cant_write_config']	= 'Impossible d\'écrire dans le fichier de configuration.';
+$lang['mb_context_exists']		= 'Le Contexte existe déjà dans le fichier de configuration.';

--- a/bonfire/application/language/english/application_lang.php
+++ b/bonfire/application/language/english/application_lang.php
@@ -131,6 +131,15 @@ $lang['bf_password_force_symbols']		= 'Should password force symbols?';
 $lang['bf_password_force_mixed_case']	= 'Should password force mixed case?';
 $lang['bf_password_show_labels']	    = 'Display password validation labels';
 
+
+//--------------------------------------------------------------------
+// ! BREADCRUMB
+//--------------------------------------------------------------------
+
+$lang['bf_context_admin']		= 'Admin';
+$lang['breadcrumb_home']		= 'Home';
+
+
 //--------------------------------------------------------------------
 // ! USER/PROFILE
 //--------------------------------------------------------------------

--- a/bonfire/application/language/french/application_lang.php
+++ b/bonfire/application/language/french/application_lang.php
@@ -1,0 +1,243 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+	Copyright (c) 2011 Lonnie Ezell
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+
+//--------------------------------------------------------------------
+// ! GENERAL SETTINGS
+//--------------------------------------------------------------------
+
+$lang['bf_site_name']			= 'Nom de site';
+$lang['bf_site_email']			= 'Email du site';
+$lang['bf_site_email_help']		= 'Email utilisé par le système lors de l\'envoie de message';
+$lang['bf_site_status']			= 'Statut du site';
+$lang['bf_online']				= 'Online';
+$lang['bf_offline']				= 'Offline';
+$lang['bf_top_number']			= 'Eléments <em>par</em> page:';
+$lang['bf_top_number_help']		= 'Lors de l\'affichage des rapports, combien d\'éléments doivent être affichés à la fois ?';
+$lang['bf_home']				= 'Accueil';
+$lang['bf_site_information']	= 'Information du site';
+$lang['bf_timezone']			= 'Zone horraire';
+$lang['bf_language']			= 'Langue';
+$lang['bf_language_help']		= 'Choisissez les langues disponibles pour les inscrits';
+
+//--------------------------------------------------------------------
+// ! AUTH SETTINGS
+//--------------------------------------------------------------------
+
+$lang['bf_security']			= 'Securité';
+$lang['bf_login_type']			= 'Type de login';
+$lang['bf_login_type_email']	= 'Email seuleument';
+$lang['bf_login_type_username']	= 'Nom d\'inscrits seuleument';
+$lang['bf_allow_register']		= 'Permettre l\'inscription d\'utilisateur ?';
+$lang['bf_login_type_both']		= 'Email ou Nom d\'utilisateur';
+$lang['bf_use_usernames']		= 'Affichage des inscrits sur Bonfire';
+$lang['bf_use_own_name']		= 'utiliser le nom';
+$lang['bf_allow_remember']		= 'Permettre \'Se souvenir de moi\' ?';
+$lang['bf_remember_time']		= 'Se souvenir de moi';
+$lang['bf_week']				= 'Semaine';
+$lang['bf_weeks']				= 'Semaines';
+$lang['bf_days']				= 'Jours';
+$lang['bf_username']			= 'Nom d\utilisateur';
+$lang['bf_password']			= 'Mot de passe';
+$lang['bf_password_confirm']	= 'Mot de passe (encore)';
+$lang['bf_display_name']		= 'Afficher le nom';
+
+//--------------------------------------------------------------------
+// ! CRUD SETTINGS
+//--------------------------------------------------------------------
+
+$lang['bf_home_page']			= 'Page d\'Accueil';
+$lang['bf_pages']				= 'Pages';
+$lang['bf_enable_rte']			= 'Autoriser le RTE pour les pages ?';
+$lang['bf_rte_type']			= 'Type de RTE';
+$lang['bf_searchable_default']	= 'Recherchable par défaut?';
+$lang['bf_cacheable_default']	= 'Mise en cache par défaut ?';
+$lang['bf_track_hits']			= 'Suivre les Hits ?';
+
+$lang['bf_action_save']			= 'Enregistrer';
+$lang['bf_action_delete']		= 'Supprimer';
+$lang['bf_action_cancel']		= 'Annuler';
+$lang['bf_action_download']		= 'Télécharger';
+$lang['bf_action_preview']		= 'Prévisualiser';
+$lang['bf_action_search']		= 'Rechercher';
+$lang['bf_action_purge']		= 'Purger';
+$lang['bf_action_restore']		= 'Restaurer';
+$lang['bf_action_show']			= 'Voir';
+$lang['bf_action_login']		= 'Se connecter';
+$lang['bf_action_logout']		= 'Se déconnecter';
+$lang['bf_actions']				= 'Actions';
+$lang['bf_clear']				= 'Effacer';
+$lang['bf_action_list']			= 'List';
+$lang['bf_action_create']		= 'Créer';
+$lang['bf_action_ban']			= 'Ban';
+
+//--------------------------------------------------------------------
+// ! SETTINGS LIB
+//--------------------------------------------------------------------
+
+$lang['bf_do_check']			= 'Rechercher des mises à jour ?';
+$lang['bf_do_check_edge']		= 'Doit être activer pour voir les dernières mises à jour';
+
+$lang['bf_update_show_edge']	= 'Voir les dernières mises à jours ?';
+$lang['bf_update_info_edge']	= 'Laisser décocher afin de voir seuleument les mises à jours annoncés. Cocher pour voir toutes les mises à jours du répertoire officiel. ';
+
+$lang['bf_ext_profile_show']	= 'les inscrits ont-il accès aux profils avancés ?';
+$lang['bf_ext_profile_info']	= 'Cocher les profils avancés afin d\'avoir des options de meta-data avancés.';
+
+$lang['bf_yes']					= 'Oui';
+$lang['bf_no']					= 'Non';
+$lang['bf_none']				= 'Vide';
+$lang['bf_id']					= 'ID';
+
+$lang['bf_or']					= 'ou';
+$lang['bf_size']				= 'Poids';
+$lang['bf_files']				= 'Fichiers';
+$lang['bf_file']				= 'Fichier';
+
+$lang['bf_with_selected']		= 'avec les sélectionnés';
+
+$lang['bf_env_dev']				= 'Developement';
+$lang['bf_env_test']			= 'Test';
+$lang['bf_env_prod']			= 'Production';
+
+$lang['bf_show_profiler']		= 'Voir le profil de l\Administrateur?';
+$lang['bf_show_front_profiler']	= 'Voir les profil sur le FrontEnd?';
+
+$lang['bf_cache_not_writable']  = 'Le répertoire de cache est protégé en écriture';
+
+$lang['bf_password_strength']			= 'Réglages des mots de passe';
+$lang['bf_password_length_help']		= 'Taille du mot de passe minimum (ex : 8)';
+$lang['bf_password_force_numbers']		= 'Le mot de passe doit-il focer les numéros ?';
+$lang['bf_password_force_symbols']		= 'Le mot de passe doit-il forcer les symboles ?';
+$lang['bf_password_force_mixed_case']	= 'Le mot de passe doit-il forcer la case ?';
+$lang['bf_password_show_labels']	    = 'Afficher les labels de validation du mot de passe';
+
+
+//--------------------------------------------------------------------
+// ! BREADCRUMB
+//--------------------------------------------------------------------
+
+$lang['bf_context_admin']		= 'Admin';
+$lang['breadcrumb_home']		= 'Accueil';
+
+
+//--------------------------------------------------------------------
+// ! USER/PROFILE
+//--------------------------------------------------------------------
+
+$lang['bf_user']				= 'Utilisateur';
+$lang['bf_users']				= 'Utilisateurs';
+$lang['bf_description']			= 'Description';
+$lang['bf_email']				= 'Email';
+$lang['bf_user_settings']		= 'Mon profil';
+
+//--------------------------------------------------------------------
+// !
+//--------------------------------------------------------------------
+
+$lang['bf_both']				= 'tous les deux';
+$lang['bf_go_back']				= 'Revenir en arrière';
+$lang['bf_new']					= 'Nouveau';
+$lang['bf_required_note']		= 'Les champs obligatoire sont en <b>gras</b>.';
+$lang['bf_form_label_required'] = '<span class="required">*</span>';
+
+//--------------------------------------------------------------------
+// MY_Model
+//--------------------------------------------------------------------
+$lang['bf_model_db_error']		= 'ErreurDB : ';
+$lang['bf_model_no_data']		= 'Pas de données disponibles.';
+$lang['bf_model_invalid_id']	= 'Invalid ID passed to model.';
+$lang['bf_model_no_table']		= 'Le Model à une table de base donnée non spécifié.';
+$lang['bf_model_fetch_error']	= 'Pas assez d\'informations pour rechercher le champs.';
+$lang['bf_model_count_error']	= 'Pas assez d\'informations pour compter les résultats.';
+$lang['bf_model_unique_error']	= 'Pas assez d\'informations pour vérifier l\'unicité.';
+$lang['bf_model_find_error']	= 'Pas assez d\'informations pour trouver.';
+$lang['bf_model_bad_select']	= 'Sélection non valide.';
+
+//--------------------------------------------------------------------
+// Contexts
+//--------------------------------------------------------------------
+$lang['bf_no_contexts']			= 'Le tableau "Contexte" n\'est pas correctement créer. Vérifier le fichier de configuration de votre application.';
+$lang['bf_context_content']		= 'Contenu';
+$lang['bf_context_reports']		= 'Raports';
+$lang['bf_context_settings']	= 'Paramètres';
+$lang['bf_context_developer']	= 'Developper';
+
+//--------------------------------------------------------------------
+// Activities
+//--------------------------------------------------------------------
+$lang['bf_act_settings_saved']	= 'Options d\'application sauvegardé de ';
+$lang['bf_unauthorized_attempt']= 'Impossible d\'accéder à la page requiairant les permissions suivantes "%s" de ';
+
+$lang['bf_keyboard_shortcuts']		= 'Racourcis claviers disponible :';
+$lang['bf_keyboard_shortcuts_none']	= 'Il n\'y a aucun racourcis clavier disponible.';
+$lang['bf_keyboard_shortcuts_edit']	= 'Mettre à jour les racourcis clavier.';
+
+//--------------------------------------------------------------------
+// Common
+//--------------------------------------------------------------------
+$lang['bf_question_mark']	      = '?';
+$lang['bf_language_direction']	= 'ltr';
+$lang['log_intro']              = 'Ce sont les messages du journal.';
+
+//--------------------------------------------------------------------
+// Login
+//--------------------------------------------------------------------
+$lang['bf_action_register']		= 'S\'inscrire';
+$lang['bf_forgot_password']		= 'Vous avez perdu votre mot de passe ?';
+$lang['bf_remember_me']			= 'Se souvenir de moi';
+
+//--------------------------------------------------------------------
+// Password Help Fields to be used as a warning on register
+//--------------------------------------------------------------------
+$lang['bf_password_number_required_help']  = 'Le mot de passe doit contenir au moins 1 chiffre.';
+$lang['bf_password_caps_required_help']    = 'Le mot de passe doit contenir au moins 1 lettre majuscule.';
+$lang['bf_password_symbols_required_help'] = 'Le mot de passe doit contenir au moins 1 symbole.';
+
+$lang['bf_password_min_length_help']       = 'Le mot de passe doit comporter au moins %s caractères.';
+$lang['bf_password_length']                = 'Longueur du mot de passe';
+
+//--------------------------------------------------------------------
+// User Meta examples
+//--------------------------------------------------------------------
+
+$lang['user_meta_street_name']	= 'Nom de la rue';
+$lang['user_meta_type']			= 'Type';
+$lang['user_meta_country']		= 'Pays';
+$lang['user_meta_state']		= 'État';
+
+// Activation
+//--------------------------------------------------------------------
+$lang['bf_activate_method']			= 'Méthode d\'activation';
+$lang['bf_activate_none']			= 'Aucune';
+$lang['bf_activate_email']			= 'Email';
+$lang['bf_activate_admin']			= 'Admin';
+$lang['bf_activate']				= 'Activer';
+$lang['bf_activate_resend']			= 'Renvoyer l\'activation';
+
+$lang['bf_reg_complete_error']		= 'Une erreur s\est produite lors de votre enregistrement. Merci de réessayer ou contacter l\'administateur du site afin d\'obtenir de l\'aide';
+$lang['bf_reg_activate_email'] 		= 'Un email contenant votre code d\'activation a été envoyé à [EMAIL].';
+$lang['bf_reg_activate_admin'] 		= 'Vous serez avertit lorsque l\'administrateur aura accepter votre enregistrement.';
+$lang['bf_reg_activate_none'] 		= 'Merci de vous connecter afin de pouvoir utiliser ce site.';
+$lang['bf_user_not_active'] 		= 'Le compte de cet utilisateur n\'est pas activé.';
+$lang['bf_login_activate_title']	= 'Besoin d\'activer votre compte ?';
+$lang['bf_login_activate_email'] 	= '<b>Avez-vous un code d\'activation pour votre enregistrement ?</b> Inscriver le sur cette page : [ACCOUNT_ACTIVATE_URL].<br /><br />    <b>Besoin de recevoir votre code d\'activation à nouveau ?</b> Cliquez ici pour le renvoyer [ACTIVATE_RESEND_URL].';

--- a/bonfire/application/language/french/datatable_lang.php
+++ b/bonfire/application/language/french/datatable_lang.php
@@ -1,0 +1,35 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/*
+	Copyright (c) 2011 Lonnie Ezell
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+	
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+	
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+*/
+$lang['sProcessing']= 'En cours d\'éxécution...';
+$lang['sLengthMenu']= 'Voir les entrées du _MENU_';
+$lang['sZeroRecords']= 'Aucun enregistrement correspondant n\'a été trouvé';
+$lang['sInfo']= 'Voir de _START_ à _END_ des _TOTAL_ entrées';
+$lang['sInfoEmpty']= 'Voir de 0 à 0 des 0 entrées';
+$lang['sInfoFiltered']= '(filtrés des _MAX_ entrées totales)';
+$lang['sInfoPostFix']= '';
+$lang['sSearch']= 'Rechercher :';
+$lang['sUrl']= '';
+$lang['sFirst']= 'Premier';
+$lang['sPrevious']= 'Précédent';
+$lang['sNext']= 'Suivant';
+$lang['sLast']= 'Dernier';

--- a/bonfire/application/language/french/index.html
+++ b/bonfire/application/language/french/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/bonfire/application/libraries/template.php
+++ b/bonfire/application/libraries/template.php
@@ -1211,7 +1211,7 @@ function breadcrumb($my_segments=NULL, $wrap=FALSE, $echo=TRUE)
 	}
 	else
 	{
-		$output  = '<a href="'.$home_link.'">home</a> '.$seperator;
+		$output  = '<a href="'.$home_link.'">'.lang('breadcrumb.home').'</a> '.$seperator;
 	}
 
 	$url = '';
@@ -1225,6 +1225,9 @@ function breadcrumb($my_segments=NULL, $wrap=FALSE, $echo=TRUE)
 			$url .= '/'. $segment;
 			$count += 1;
 
+			$lang_segment = lang($segment);
+			$lang_segment2 = (empty($lang_segment)) ? lang('bf_context_'.$segment) : $lang_segment;
+			$segment = (empty($lang_segment2)) ? $lang_segment : $lang_segment2;
 			if ($count == $total)
 			{
 				if ($wrap === TRUE)


### PR DESCRIPTION
Translation for french version,  fixed using "lang()" where there are static string And fixed error Title table on user views, add new entries on application_lang and each module (and core_module) for breadcrumb translation.

Maybe add "French" branch and not merge into develop/ because core_modules does not support  translation by lang() and are been translated in config file directly.
- Partial translation -> must be know if technical words must be translate like "Controller, Models, Views, or Database, Form Input. In my opinion, we could let technical words in english because it's current usage of using english in programming
- In order to translated breadcrumb, add new rules, see above
###### ################ NEW RULES LANG FILES

Add new entries on each language file of each module (and core_module) like $lang['module_name'] = 'Module Name'; in order to use on breadcrumb translation.
If node breadcrumb is a context, this translation is on application_lang $lang['bf_context_NAMEofCONTEXT'] and must be add on New Context)
For example, see "activites" core module.
###### 

Translated :
- application_lang
- database_lang
- /core_modules/activities/
- /core_modules/builder/

Add new entries on application_lang to next translation breadcrumb which is ommited

Add fix forgotten "lang()" using :
- Activities core modules :
  > /core_modules/activities/controllers/reports.php
  > /core_modules/activities/views/reports/index.php
- Breadcrumb function on Template :
  > /librairies/template.php

Add a test on the user language to add a special particle just for french version in special case:
- /core_modules/activities/views/reports/view.php

Add fix thead error (module -> user) on top_user table :
- /core_modules/activities/views/reports/index.php
