### PR TITLE
Referential integrity table relation.

### DIFF
--- a/bonfire/modules/builder/config/modulebuilder.php
+++ b/bonfire/modules/builder/config/modulebuilder.php
@@ -7,9 +7,9 @@ $config[ 'modulebuilder' ]['output_path'] = APPPATH."/modules/";
 /*
  * form actions which will appear in the list
  */
-$config[ 'modulebuilder' ][ 'form_action_options' ] = array('index' => 'List',
+$config[ 'modulebuilder' ][ 'form_action_options' ] = array('index' => 'List', 
 														'create' => 'Create',
-														'edit' => 'Edit',
+														'edit' => 'Edit', 
 														'delete' => 'Delete');
 
 
@@ -18,7 +18,7 @@ $config[ 'modulebuilder' ][ 'form_action_options' ] = array('index' => 'List',
  */
 $config[ 'modulebuilder' ][ 'validation_rules' ] = array('required', 'unique', 'trim');
 $config[ 'modulebuilder' ][ 'validation_limits' ] = array('alpha', 'is_numeric', 'alpha_numeric', 'alpha_dash', 'valid_email', 'integer', 'is_decimal', 'is_natural', 'is_natural_no_zero','valid_ip','valid_base64','alpha_extra');
-
+														
 /*
  * default primary key field
  */

--- a/bonfire/modules/builder/language/english/builder_lang.php
+++ b/bonfire/modules/builder/language/english/builder_lang.php
@@ -22,7 +22,6 @@
 */
 
 // INDEX page
-$lang['mb_delete_confirm']		= 'Really delete this module and all of its files?';
 $lang['mb_create_button']		= 'Create Module';
 $lang['mb_create_link']			= 'Create a new module';
 $lang['mb_create_note']			= 'Use our wizbang module building wizard to create your next module. We do all the heavy lifting by generating all the controllers, models, views and language files you need.';
@@ -64,10 +63,10 @@ $lang['mb_form_note'] = '<p><b>Fill out the fields you would like in your module
 
 $lang['mb_table_note'] = '<p>Your table will be created with at least one field, the primary key field that will be used as a unique identifier and as an index. If you required additional fields, click the number you require to add them to this form.</p>';
 
-$lang['mb_field_note'] = '<p><b>NOTE : FOR ALL FIELDS</b><br />If DB field type is "enum" or "set", please enter the values using this format: \'a\',\'b\',\'c\'...<br />If you ever need to put a backslash ("\\") or a single quote ("\'") amongst those values, precede it with a backslash (for example \'\\\\xyz\' or \'a\\\'b\').</p>';
+$lang['mb_field_note'] = '<p><b>NOTE : FOR ALL FIELDS</b><br />If DB field type is "enum" or "set", please enter the values using this format: \'a\',\'b\',\'c\'...<br />If you ever need to put a backslash ("\") or a single quote ("\'") amongst those values, precede it with a backslash (for example \'\\xyz\' or \'a\\\'b\').</p>';
 	
 $lang['mb_form_errors']			= 'Please correct the errors below.';
-$lang['mb_form_mod_details']	= 'Module Details';
+$lang['mb_form_mod_details']	= 'Module Details ';
 $lang['mb_form_mod_name']		= 'Module Name';
 $lang['mb_form_mod_name_ph']	= 'Forums, Blog, ToDo';
 $lang['mb_form_mod_desc']		= 'Module Description';
@@ -120,6 +119,10 @@ $lang['mb_form_is_natural_no_zero']	= 'Natural, no zeroes';
 $lang['mb_form_valid_ip']		= 'Valid IP';
 $lang['mb_form_valid_base64']	= 'Valid Base64';
 $lang['mb_form_alpha_extra']	= 'AlphaNumerics, underscore, dash, periods and spaces.';
+// Enhanced Parent-Child Builder Functionality - Form labels
+$lang['mb_form_reference']		= 'Reference Display';
+$lang['mb_form_nullable']		= 'Nullable';
+$lang['mb_form_children']		= 'Primary Key Children';
 
 // Activities
 $lang['mb_act_create']	= 'Created Module';

--- a/bonfire/modules/builder/language/persian/builder_lang.php
+++ b/bonfire/modules/builder/language/persian/builder_lang.php
@@ -64,7 +64,7 @@ $lang['mb_form_note'] = '<p><b>فيلد هاي مورد نياز افزونه ر
 
 $lang['mb_table_note'] = '<p>جدول پايگاه داده حداقل بايد شامل يک فيلد باشد ، کليد اصلي جهت ايندکس گذاري استفاده مي شود و يکتا است. اگر فيلد هاي بيشتري نياز داريد ، بر روي تعداد مورد نياز کليک کنيد تا به فرم اضافه شوند.</p>';
 
-$lang['mb_field_note'] = '<p><b>نکته :</b><br />اگر نوع فيلد "enum" و يا "set" باشد ، لطفا مقدار را با استفاده از اين فرمت وارد کنيد : \'a\',\'b\',\'c\'...<br />اگر به بک اسلش نياز بود ("\\") يا علامت نقل قول ("\'") از بک بک اسلش اضافي استفاده کنيد (براي مثال \'\\\\xyz\' يا \'a\\\'b\').</p>';
+$lang['mb_field_note'] = '<p><b>نکته :</b><br />اگر نوع فيلد "enum" و يا "set" باشد ، لطفا مقدار را با استفاده از اين فرمت وارد کنيد : \'a\',\'b\',\'c\'...<br />اگر به بک اسلش نياز بود ("\") يا علامت نقل قول ("\'") از بک بک اسلش اضافي استفاده کنيد (براي مثال \'\\xyz\' يا \'a\\\'b\').</p>';
 
 $lang['mb_form_errors']			= 'لطفا خطا هاي مقابل را تصحيح نماييد.';
 $lang['mb_form_mod_details']	= 'توضيحات افزونه ';
@@ -119,6 +119,10 @@ $lang['mb_form_is_natural_no_zero']	= 'طبيعي بدون صفر';
 $lang['mb_form_valid_ip']		= 'IP معتبر';
 $lang['mb_form_valid_base64']	= 'Base64 معتبر';
 $lang['mb_form_alpha_extra']	= 'حروف الفبا, خط زير, خط تيره, نقطه و خط فاصله.';
+// Enhanced Parent-Child Builder Functionality - Form labels
+$lang['mb_form_reference']		= 'Reference Display';
+$lang['mb_form_nullable']		= 'Nullable';
+$lang['mb_form_children']		= 'Primary Key Children';
 
 // Activities
 $lang['mb_act_create']	= 'ايجاد افزونه';

--- a/bonfire/modules/builder/views/developer/create_context.php
+++ b/bonfire/modules/builder/views/developer/create_context.php
@@ -43,8 +43,8 @@
 		</div>
 		-->
 		<div class="form-actions">
-			<input type="submit" name="build" class="btn btn-primary" value="Create It" /> or
-			<a href="<?php echo site_url(SITE_AREA .'/developer/builder') ?>"><?php e(lang('bf_action_cancel')) ?></a>
+			<input type="submit" name="submit" class="btn btn-primary" value="Create It" /> or 
+			<a href="<?php echo site_url(SITE_AREA .'/developer/builder') ?>">Cancel</a>
 		</div>
 	
 	<?php echo form_close(); ?>

--- a/bonfire/modules/builder/views/developer/index.php
+++ b/bonfire/modules/builder/views/developer/index.php
@@ -4,6 +4,8 @@
 	</div>
 <?php endif;?>
 
+<br/>
+
 <div class="admin-box">
 	<h3><?php echo lang('mb_exist_modules') ?></h3>
 
@@ -29,7 +31,7 @@
 				<td>
 					<?php echo form_open(SITE_AREA .'/developer/builder/delete'); ?>
 					<input type="hidden" name="module" value="<?php echo preg_replace("/[ -]/", "_", $config['name']); ?>">
-					<input type="submit" class="btn btn-danger" onclick="return confirm('<?php e(js_escape(lang('mb_delete_confirm'))) ?>');" value="<?php e(lang('bf_action_delete')) ?>" />
+					<input type="submit" class="btn btn-danger" onclick="return confirm('Really delete this module and all of its files?');" value="<?php echo lang('bf_action_delete') ?>" />
 					<?php echo form_close(); ?>
 				</td>
 			</tr>

--- a/bonfire/modules/builder/views/developer/modulebuilder_form.php
+++ b/bonfire/modules/builder/views/developer/modulebuilder_form.php
@@ -1,3 +1,59 @@
+<?php
+/**
+ * Enhanced Parent-Child Builder Functionality to support:
+ *
+ *    - Show Parent Display Name instead of parent foreign key value on index pages
+ *    - Show Tabs with Child index pages on edit pages
+ *    - Support Nullable columns
+ */
+
+// Enhanced Parent-Child Builder Functionality - modified modulebuilder_set_checkbox
+if ( ! function_exists('modulebuilder_set_checkbox'))
+{
+	function modulebuilder_set_checkbox($field = '', $value = '', $default = FALSE)
+	{
+		if ( ! isset($_POST[$field]))
+		{
+			if ($default == TRUE)
+			{
+				return ' checked="checked"';
+			}
+			return '';
+		}
+
+		$OBJ =& _get_validation_object();
+
+		if ($OBJ === FALSE)
+		{
+			$field = $_POST[$field];
+
+			if (is_array($field))
+			{
+				if ( ! in_array($value, $field))
+				{
+					return '';
+				}
+			}
+			else
+			{
+				if (($field == '' OR $value == '') OR ($field != $value))
+				{
+					return '';
+				}
+			}
+
+			return ' checked="checked"';
+		}
+
+		return $OBJ->set_checkbox($field, $value, $default);
+	}
+}
+// Enhanced Parent-Child Builder Functionality - end of modified modulebuilder_set_checkbox
+
+// Enhanced Parent-Child Builder Functionality - Add nullable attribute to validation rules
+$validation_rules[] = 'nullable';
+// Enhanced Parent-Child Builder Functionality - end of Add nullable attribute to validation rules
+?>
 <style>
 .faded {
 	opacity: .60;
@@ -249,6 +305,18 @@ a.mb_show_advanced_rules:hover {
 				</div>
 			</div>
 
+<?php // Enhanced Parent-Child Builder Functionality - Add Child Tables
+		$children = set_value("primary_key_children", ( isset( $existing_table_fields[0]) && @$existing_table_fields[0]['children'] ) ? str_replace( ',', "\n", $existing_table_fields[0]['children'] ) : '' );
+?>
+			<div class="control-group mb_new_table <?php echo form_has_error('primary_key_children') ? 'error' : ''; ?>">
+				<label for="primary_key_children" class="control-label block"><?php echo lang('mb_form_children'); ?></label>
+				<div class="controls">
+					<textarea name="primary_key_children" id="primary_key_children" rows="<?php count(explode("\n",$children))+1;?>"><?php echo $children; ?></textarea>
+					<span class="help-inline"><?php echo form_error('primary_key_children'); ?></span>
+				</div>
+			</div>
+<?php // Enhanced Parent-Child Builder Functionality - End of Add Child Tables ?>
+
 			<div id="field_numbers" class="control-group">
 				<label class="control-label"><?php echo lang('mb_form_fieldnum'); ?></label>
 				<div class="controls" style="padding-top: 5px;">
@@ -296,10 +364,33 @@ a.mb_show_advanced_rules:hover {
 						</div>
 					</div>
 
+<?php // Enhanced Parent-Child Builder Functionality - Add Reference column selection
+$has_references = ( isset( $existing_table_fields[$count]['references'] ) and !empty( $existing_table_fields[$count]['references'] ) );
+if ( $has_references ) :
+	$reference = strtolower( $existing_table_fields[$count]['references'] );
+	$ref = explode( '.', $reference );
+	$ref_table  = $ref[0];
+	$ref_column = $ref[1];
+	$ref_fields = array();
+	$ref_default = '';
+	$ref_query_string = "SHOW COLUMNS FROM ".$this->db->dbprefix.$ref_table;
+	if ( $ref_query = $this->db->query( $ref_query_string ) ) {
+		foreach( $ref_query->result_array() as $ref ) {
+			$ref_fields[ strtolower( $reference . '.' . $ref['Field'] ) ] = ucwords( str_replace( '_', ' ', $ref['Field'] ) );
+			if ( empty( $ref_default ) and strpos( strtolower( $ref[ 'Type' ] ), 'char' ) !== FALSE ) $ref_default = $reference . '.' . strtolower( $ref['Field'] );
+		}
+	}
+endif;
+// Enhanced Parent-Child Builder Functionality - end of Reference column selection
+?>
+
 					<?php
 						$view_field_types = array(
 							'input' 	=> 'INPUT',
 							'checkbox' 	=> 'CHECKBOX',
+// Enhanced Parent-Child Builder Functionality - Add Reference lookup option
+							'lookup'	=> 'LOOKUP',
+// Enhanced Parent-Child Builder Functionality - end of Add Reference lookup option
 							'password' 	=> 'PASSWORD',
 							'radio' 	=> 'RADIO',
 							'select' 	=> 'SELECT',
@@ -325,10 +416,19 @@ a.mb_show_advanced_rules:hover {
 							}
 						}
 
-					?>
-					<?php echo form_dropdown("view_field_type{$count}", $view_field_types, set_value("view_field_type{$count}", $default_field_type), lang('mb_form_type'), '', '<span class="help-inline">'. form_error("view_field_type{$count}").'</span>'); ?>
+						// Enhanced Parent-Child Builder Functionality - Add Reference column lookup
+						if ( $has_references ) $default_field_type = 'lookup';
+						else unset( $view_field_types[ 'lookup' ] );
+						// Enhanced Parent-Child Builder Functionality - End of Reference column lookup
+						echo form_dropdown("view_field_type{$count}", $view_field_types, set_value("view_field_type{$count}", $default_field_type), lang('mb_form_type'), '', '<span class="help-inline">'. form_error("view_field_type{$count}").'</span>');
 
-					<?php
+						// Enhanced Parent-Child Builder Functionality - Add Reference column selection
+						if ( $has_references )
+						{
+							echo form_dropdown("view_field_reference{$count}", $ref_fields, set_value("view_field_reference{$count}", $ref_default), lang('mb_form_reference'), '', '<span class="help-inline">'. form_error("view_field_reference{$count}").'</span>');
+						}
+						// Enhanced Parent-Child Builder Functionality - end of Reference column selection
+
 						$db_field_types = array(
 							'VARCHAR' 		=> 'VARCHAR',
 							'BIGINT' 		=> 'BIGINT',
@@ -389,7 +489,7 @@ a.mb_show_advanced_rules:hover {
 							<?php foreach ($validation_rules as $validation_rule) : ?>
 							<span class="faded">
 								<label class="inline checkbox" for="validation_rules_<?php echo $validation_rule . $count; ?>">
-									<input name="validation_rules<?php echo $count; ?>[]" id="validation_rules_<?php echo $validation_rule . $count; ?>" type="checkbox" value="<?php echo $validation_rule; ?>" <?php echo set_checkbox('validation_rules'.$count.'[]', $validation_rule); ?> />
+									<input name="validation_rules<?php echo $count; ?>[]" id="validation_rules_<?php echo $validation_rule . $count; ?>" type="checkbox" value="<?php echo $validation_rule; ?>" <?php echo modulebuilder_set_checkbox('validation_rules'.$count, $validation_rule /* Enhanced Parent-Child Builder - add default value from existing_table_fields if available */, isset( $existing_table_fields[$count][$validation_rule] ) and TRUE == $existing_table_fields[$count][$validation_rule] /* Enhanced Parent-Child Builder - end of default value */ ); ?> />
 									<?php echo lang('mb_form_'.$validation_rule); ?>
 								</label>
 							</span>
@@ -402,6 +502,7 @@ a.mb_show_advanced_rules:hover {
 					<div class="control-group mb_advanced">
 						<label class="control-label" id="validation_limit_label<?php echo $count; ?>"><?php echo lang('mb_form_rules_limits'); ?></label>
 						<div class="controls" aria-labelledby="validation_limit_label<?php echo $count; ?>" role="group">
+							<?php echo lang('mb_form_rules_limit_note'); ?>
 							<?php foreach ($validation_limits as $validation_limit) : ?>
 							<span class="faded">
 								<label class="inline radio" for="validation_rules_<?php echo $validation_limit . $count; ?>">
@@ -432,7 +533,7 @@ a.mb_show_advanced_rules:hover {
 	</div>
 	<div class="form-actions">
 		<?php if ($writeable): ?>
-			<?php echo form_submit('build', 'Build the Module', 'class="btn btn-primary"'); ?>
+			<?php echo form_submit('submit', 'Build the Module', 'class="btn btn-primary"'); ?>
 		<?php endif;?>
 	</div>
 	<?php echo form_close()?>

--- a/bonfire/modules/builder/views/files/lang.php
+++ b/bonfire/modules/builder/views/files/lang.php
@@ -32,6 +32,10 @@ $lang[\''.$module_name_lower.'_edit_heading\']			= \'Edit '.$module_name.'\';
 $lang[\''.$module_name_lower.'_act_create_record\']			= \'Created record with ID\';
 $lang[\''.$module_name_lower.'_act_edit_record\']			= \'Updated record with ID\';
 $lang[\''.$module_name_lower.'_act_delete_record\']			= \'Deleted record with ID\';
+
+// Enhanced Parent-Child Builder - Add Delete Selected
+$lang[\''.$module_name_lower.'_delete_selected\']			= \'Delete selected '.$module_name.'\';
+$lang[\''.$module_name_lower.'_no_records_found\']			= \'No '.$module_name.' were found that match your selection.\';
 ';
 
 echo $lang;

--- a/bonfire/modules/builder/views/files/model.php
+++ b/bonfire/modules/builder/views/files/model.php
@@ -24,7 +24,127 @@ class '.ucfirst($controller_name).'_model extends BF_Model {
 	protected $modified_field = "'.$this->input->post('modified_field').'";';		
 	}	
 	
-	
+// Enhanced Parent-Child Builder - Add column definitions
+	$pk = $this->input->post( "primary_key_field" );
+	$columns = "'{$pk}' => array( 'name' => '{$pk}', 'label' => '" . ucwords(str_replace( '_', ' ', $pk ) ) . "' )";
+	$atts = array( 'name', 'label', 'reference' );
+	for ( $counter = 0; $counter <= $field_total; $counter++ ) {
+		if ( $colname = $this->input->post( "view_field_name{$counter}" ) )
+		{
+			$colatts = '';
+			foreach ( $atts as $att ) $colatts .= ", '{$att}' => '" . $this->input->post( "view_field_{$att}{$counter}" ) . "'";
+			$colatts = ltrim( $colatts, ",\t\n\r " );
+			$columns .= "
+								,'{$colname}' => array( {$colatts} )";
+		}
+	}
+	$columns = ltrim( $columns, ",\t\n\r" );
+	$model .= "
+
+	// Columns
+	protected \$columns = array( {$columns}
+							);";
+// Enhanced Parent-Child Builder - end of Add column definitions
+
+// Enhanced Parent-Child Builder - Add child tables
+	$children = str_replace( "\n", ',', trim( $this->input->post( 'primary_key_children' ), "\n\r,. " ) );
+	$childtables = array();
+	$childvalue = '';
+	if ( !empty( $children ) )
+	{
+		foreach ( explode( ",", strtolower( $children ) ) as $child )
+		{
+			$child = trim( $child, "\n\r,. " );
+			$f = explode( '.', trim( $child, "\n\r,. " ) );
+			if ( count( $f ) < 2 ) break;
+			if ( count( $f ) == 2 ) $f[] = ucwords( $f[0] );
+			if ( !isset( $childtables[ $f[0] ] ) ) $childtables[ $f[0] ] = array();
+			$childtables[ $f[0] ][] = $child;
+			$childvalue .= "
+								,'{$f[0]}.{$f[1]}' => array( 'table' => '{$f[0]}', 'column' => '{$f[1]}', 'label' => '{$f[2]}' )";
+		}
+		if ( empty( $childvalue ) ) $childvalue = '';
+		else $childvalue = trim( $childvalue, ",\t\n\r" );
+	}
+	$model .= "
+
+	// Known Children
+	protected \$children	= array( {$childvalue}
+							);";
+// Enhanced Parent-Child Builder - end of Add child tables
+
+// Enhanced Parent-Child Builder - Add References to selection & build check_nulls content
+	$selects = $joins = $functions = '';
+	$reftables = array();
+	for ( $counter = 0; $counter <= $field_total; $counter++ ) {
+		if ( $ref = $this->input->post( "view_field_reference{$counter}" ) and $this->input->post( "view_field_label{$counter}" ) and $this->input->post( "view_field_name{$counter}" ) ) {
+			$refparts = explode( '.', $ref );
+			if ( !array_key_exists( $refparts[0], $reftables ) ) $reftables[ $refparts[0] ] = '';
+			$colname  = $this->input->post( "view_field_name{$counter}" );
+			$selects .= ', ' . $refparts[0] . $reftables[$refparts[0]] . '.' . $refparts[2] . ' as ' . $refparts[0] . $reftables[$refparts[0]] . '_' . $refparts[2];
+			$joins   .= "\n\t\t\$this->db->join( '{$refparts[0]} {$refparts[0]}{$reftables[$refparts[0]]}', '{$refparts[0]}{$reftables[$refparts[0]]}.{$refparts[1]} = {$table_name}.{$colname}', 'left outer' );";
+			if ( '' == $reftables[ $refparts[0] ] ) $reftables[ $refparts[0] ] = 2;
+			else $reftables[ $refparts[0] ] += 1;
+			$where = "'{$refparts[1]}' => \$where";
+			if ( isset( $childtables[ $refparts[0] ] ) )
+			{
+				$where = '';
+				foreach ( $childtables[ $refparts[0] ] as $t )
+				{
+					$t = explode( '.', $t );
+					$where .= ", '{$t[1]}' => \$where";
+				}
+				$where = substr( $where, 2 );
+			}
+			$functions .= "
+
+	public function {$colname}_format_dropdown( \$where = NULL, \$withnull = FALSE )
+	{
+		if ( !is_array( \$where ) )
+		{
+			if ( is_numeric( \$where ) ) \$where = array( '{$refparts[1]}' => \$where );
+			elseif ( 1 == count( func_get_args() ) )
+			{
+				\$withnull = \$where;
+				\$where = NULL;
+			}
+		}
+		\$this->load->model( '{$refparts[0]}/{$refparts[0]}_model', NULL, TRUE );
+		\${$refparts[0]} = new " . ucwords( $refparts[0] ) . "_Model();
+		if ( is_array( \$where ) ) \${$refparts[0]}->db->where( \$where );
+		\$dropdown = \${$refparts[0]}->format_dropdown( '{$refparts[2]}' );
+		if ( !\$withnull ) return \$dropdown;
+		\$return = array( 'null' => ' ' );
+		foreach ( \$dropdown as \$key => \$value ) \$return[ \$key ] = \$value;
+		return \$return;
+	}";
+		}
+		if ( $v = $this->input->post( "validation_rules{$counter}" ) and $this->input->post( "view_field_label{$counter}" ) and $this->input->post( "view_field_name{$counter}" ) ) {
+			$v = array_flip( $v );
+			if ( isset( $v['nullable'] ) ) $field_name = set_value( "view_field_name{$counter}" );
+		}
+	}
+	if ( !empty( $selects ) ) {
+		$model .= "
+
+	protected \$before_find = array( 'before_find' );
+
+	protected function before_find()
+	{
+		\$this->selects = '{$table_name}.*{$selects}';{$joins}
+	}{$functions}
+";
+
+	}
+
+	$model .= '
+
+	public function get_columns() { return $this->columns; }
+
+	public function get_children() { return $this->children; }
+';
+
+// Enhanced Parent-Child Builder - End of References	
 	$model .= 
 '
 }

--- a/bonfire/modules/builder/views/files/view_index.php
+++ b/bonfire/modules/builder/views/files/view_index.php
@@ -7,22 +7,40 @@ $view =<<<END
 		<table class="table table-striped">
 			<thead>
 				<tr>
+					<?php \$tblcols_total = {tblcols_total}; ?>
 					<?php if (\$this->auth->has_permission('{delete_permission}') && isset(\$records) && is_array(\$records) && count(\$records)) : ?>
 					<th class="column-check"><input class="check-all" type="checkbox" /></th>
+					<?php endif;?>
+					<?php if ( isset(\$records) && is_array(\$records) && count(\$records) && ( \$this->auth->has_permission('{edit_permission}') || \$this->auth->has_permission('{view_permission}') ) ) : ?>
+					<th class="column-check">&nbsp;</th>
+					<?php \$tblcols_total += 1; ?>
 					<?php endif;?>
 					{table_header}
 				</tr>
 			</thead>
 			<?php if (isset(\$records) && is_array(\$records) && count(\$records)) : ?>
 			<tfoot>
-				<?php if (\$this->auth->has_permission('{delete_permission}')) : ?>
+				<?php if (\$this->auth->has_permission('{delete_permission}') or \$this->auth->has_permission('{create_permission}')) : ?>
 				<tr>
 					<td colspan="{cols_total}">
-						<?php echo lang('bf_with_selected') ?>
-						<input type="submit" name="delete" id="delete-me" class="btn btn-danger" value="<?php echo lang('bf_action_delete') ?>" onclick="return confirm('<?php e(js_escape(lang('{$module_name_lower}_delete_confirm'))); ?>')">
+					<?php if (\$this->auth->has_permission('{delete_permission}')) : ?>
+						<?php // echo lang('bf_with_selected') ?>
+						<input type="submit" name="delete" id="delete-me" class="btn btn-danger" value="<?php echo lang('{$module_name_lower}_delete_selected') ?>" onclick="return confirm('<?php e(js_escape(lang('{$module_name_lower}_delete_confirm'))); ?>')">
+					<?php endif; ?>
+					<?php if (\$this->auth->has_permission('{create_permission}')) : ?>
+						<a class="btn btn-primary" href="<?php echo site_url(SITE_AREA.'/content/{$module_name_lower}/create?') . http_build_query(\$_GET) ;?>"><?php echo lang('{$module_name_lower}_new') ?> {$module_name}</a>
+						<?php endif; ?>
 					</td>
 				</tr>
 				<?php endif;?>
+			</tfoot>
+			<?php elseif (\$this->auth->has_permission('{create_permission}')) : ?>
+			<tfoot>
+				<tr>
+					<td colspan="{cols_total}">
+						<a class="btn btn-primary" href="<?php echo site_url(SITE_AREA.'/content/{$module_name_lower}/create?') . http_build_query(\$_GET) ;?>"><?php echo lang('{$module_name_lower}_new') ?> {$module_name}</a>
+					</td>
+				</tr>
 			</tfoot>
 			<?php endif; ?>
 			<tbody>
@@ -37,15 +55,18 @@ $view =<<<END
 			<?php endforeach; ?>
 			<?php else: ?>
 				<tr>
-					<td colspan="{cols_total}">No records found that match your selection.</td>
+					<td colspan="{cols_total}"><?php echo lang('{$module_name_lower}_no_records_found');?></td>
 				</tr>
 			<?php endif; ?>
 			</tbody>
 		</table>
+		<?php if ( \$this->pagination->total_rows > \$this->pagination->per_page ) echo \$this->pagination->create_links(); ?>
 	<?php echo form_close(); ?>
+
 </div>
 END;
 
+$columns = array();
 $headers = '';
 for($counter=1; $field_total >= $counter; $counter++)
 {
@@ -59,25 +80,31 @@ for($counter=1; $field_total >= $counter; $counter++)
 	}
 	$headers .= '
 					<th>'. set_value("view_field_label$counter").'</th>';
+	$columns[set_value("view_field_name$counter")] = set_value("view_field_name$counter");
 }
+
 if ($use_soft_deletes == 'true')
 {
 	$headers .= '
 					<th>Deleted</th>';
 }
-if ($use_created == 'true')
+if ($use_created == 'true' && NULL != set_value("created_field") && !isset( $columns[ set_value("created_field") ] ) )
 {
 	$headers .= '
 					<th>Created</th>';
 }
-if ($use_modified == 'true')
+if ($use_modified == 'true' && NULL != set_value("modified_field") && !isset( $columns[ set_value("modified_field") ] ) )
 {
 	$headers .= '
 					<th>Modified</th>';
 }
 
 $table_records = '';
-$pencil_icon   = "'<i class=\"icon-pencil\">&nbsp;</i>' . ";
+$pencil_icon   = "'<i class=\"icon-pencil\">&nbsp;</i>'";
+$edit_icon     = "'<i class=\"icon-pencil\">&nbsp;</i>&nbsp;'";
+$view_icon     = "'<i class=\"icon-book\">&nbsp;</i>&nbsp;'";
+$delete_icon   = "'<i class=\"icon-remove\">&nbsp;</i>&nbsp;'";	// remove	remove-circle
+$field_counter = 0;
 for($counter=1; $field_total >= $counter; $counter++)
 {
 	// only build on fields that have data entered.
@@ -88,6 +115,8 @@ for($counter=1; $field_total >= $counter; $counter++)
 	{
 		continue; 	// move onto next iteration of the loop
 	}
+
+	$field_counter++;
 
 	if($db_required == 'new' && $table_as_field_prefix === TRUE)
 	{
@@ -102,13 +131,22 @@ for($counter=1; $field_total >= $counter; $counter++)
 		$field_name = set_value("view_field_name$counter");
 	}
 
+// Enhanced Parent-Child Builder - Add Reference column
+if ( $ref = $this->input->post( "view_field_reference$counter" ) ) {
+	$ref = explode( '.', $ref );
+	$field_name = $ref[0] . '_' . $ref[2];
+}
+// Enhanced Parent-Child Builder - End of Refference column
+
 	if ($counter == 1) {
 		$table_records .= "
-				<?php if (\$this->auth->has_permission('{edit_permission}')) : ?>
-				<td><?php echo anchor(SITE_AREA .'/".$controller_name."/".$module_name_lower."/edit/'. \$record->".$primary_key_field.", {$pencil_icon} \$record->".$field_name.") ?></td>
-				<?php else: ?>
+				<?php // Add Permitted Actions
+					if (\$this->auth->has_permission('{edit_permission}'))
+						echo '<td>'.anchor(SITE_AREA .'/".$controller_name."/".$module_name_lower."/edit/'. \$record->".$primary_key_field.", {$edit_icon}).'</td>';
+					elseif (\$this->auth->has_permission('{view_permission}'))
+						echo '<td>'.anchor(SITE_AREA .'/".$controller_name."/".$module_name_lower."/edit/'. \$record->".$primary_key_field.", {$view_icon}).'</td>';
+				?>
 				<td><?php e(\$record->".$field_name.") ?></td>
-				<?php endif; ?>
 			";
 	}
 	else {
@@ -122,13 +160,13 @@ if ($use_soft_deletes == 'true')
 				<td><?php echo $record->deleted > 0 ? lang(\''.$module_name_lower.'_true\') : lang(\''.$module_name_lower.'_false\')?></td>';
 	$field_total++;
 }
-if ($use_created == 'true')
+if ($use_created == 'true' && NULL != set_value("created_field") && !isset( $columns[ set_value("created_field") ] ) )
 {
 	$table_records .= '
 				<td><?php e($record->'.set_value("created_field").') ?></td>';
 	$field_total++;
 }
-if ($use_modified == 'true')
+if ($use_modified == 'true' && NULL != set_value("modified_field") && !isset( $columns[ set_value("modified_field") ] ) )
 {
 	$table_records .= '
 				<td><?php e($record->'.set_value("modified_field").') ?></td>';
@@ -137,11 +175,15 @@ if ($use_modified == 'true')
 
 
 
-$view = str_replace('{cols_total}', $field_total + 1 , $view);
+$view = str_replace('{tblcols_total}', $field_counter + 1 , $view);
+$view = str_replace('{cols_total}', '<?php echo $tblcols_total; ?>' , $view);
+$view = str_replace('{cols_total_minus_one}', '<?php echo $tblcols_total-1; ?>' , $view);
 $view = str_replace('{table_header}', $headers, $view);
 $view = str_replace('{table_records}', $table_records, $view);
 $view = str_replace('{delete_permission}', preg_replace("/[ -]/", "_", ucfirst($module_name)).'.'.ucfirst($controller_name).'.Delete', $view);
 $view = str_replace('{edit_permission}', preg_replace("/[ -]/", "_", ucfirst($module_name)).'.'.ucfirst($controller_name).'.Edit', $view);
+$view = str_replace('{view_permission}', preg_replace("/[ -]/", "_", ucfirst($module_name)).'.'.ucfirst($controller_name).'.View', $view);
+$view = str_replace('{create_permission}', preg_replace("/[ -]/", "_", ucfirst($module_name)).'.'.ucfirst($controller_name).'.Create', $view);
 
 echo $view;
 


### PR DESCRIPTION
Bonfire code builder module.

Showing parent name/description in queries instead of parent ID
Including parent rows in create/edit dropdowns for selection
Including list of related children in jQuery UI Tabs in view_default
Set nullable fields to NULL instead of default value when nothing is
entered

extracted from:
https://github.com/wescleveland56/Bonfire/tree/feature/enhanced-build-parent-child.

more details on:
http://forums.cibonfire.com/discussion/1086
