### PR TITLE
Bugfix: Module Builder Create from Existing Table - Maintenance Fields

### DIFF
--- a/bonfire/modules/builder/assets/js/modulebuilder.js
+++ b/bonfire/modules/builder/assets/js/modulebuilder.js
@@ -8,6 +8,7 @@ function show_table_props() {
 	if ($('#db_create').is(':checked')) {
 		$('#db_details').show(0);
 		$('#db_details .mb_advanced').hide();
+		$('.match-existing-notes').hide();
 		$('.mb_new_table').show(0);
 		$('#field_numbers').show(0);
 		$('#all_fields').show(0);
@@ -18,6 +19,7 @@ function show_table_props() {
 	} else if ($('#db_exists').is(':checked')) {
 		$('#db_details').show(0);
 		$('#db_details .mb_advanced').show();
+		$('.match-existing-notes').show();
 		$('.mb_new_table').hide(0);
 		$('#field_numbers').hide(0);
 		$('#all_fields').hide(0);
@@ -40,6 +42,7 @@ function show_table_props() {
 	} else {
 		$('#db_details').hide(0);
 		$('#all_fields').hide(0);
+		$('.match-existing-notes').hide();
 	}
 }
 

--- a/bonfire/modules/builder/controllers/developer.php
+++ b/bonfire/modules/builder/controllers/developer.php
@@ -388,6 +388,7 @@ class Developer extends Admin_Controller {
                 $this->form_validation->set_rules("primary_key_field",'Primary Key Field',"required|trim|xss_clean|alpha_dash");
                 $this->form_validation->set_rules("textarea_editor",'Textarea Editor',"trim|xss_clean|alpha_dash");
                 $this->form_validation->set_rules("use_soft_deletes",'Soft Deletes',"trim|xss_clean|alpha");
+                $this->form_validation->set_rules("soft_delete_field",'Soft Deletes Fieldname',"trim|xss_clean|alpha");
                 $this->form_validation->set_rules("use_created",'Use Created Field',"trim|xss_clean|alpha");
                 $this->form_validation->set_rules("created_field",'Created Field Name',"trim|xss_clean|alpha_dash");
                 $this->form_validation->set_rules("use_modified",'Use Modified Field',"trim|xss_clean|alpha");

--- a/bonfire/modules/builder/language/english/builder_lang.php
+++ b/bonfire/modules/builder/language/english/builder_lang.php
@@ -120,6 +120,7 @@ $lang['mb_form_is_natural_no_zero']	= 'Natural, no zeroes';
 $lang['mb_form_valid_ip']		= 'Valid IP';
 $lang['mb_form_valid_base64']	= 'Valid Base64';
 $lang['mb_form_alpha_extra']	= 'AlphaNumerics, underscore, dash, periods and spaces.';
+$lang['mb_form_match_existing']	= 'Ensure this matches the existing fieldname!';
 
 // Activities
 $lang['mb_act_create']	= 'Created Module';

--- a/bonfire/modules/builder/language/french/builder_lang.php
+++ b/bonfire/modules/builder/language/french/builder_lang.php
@@ -119,6 +119,7 @@ $lang['mb_form_is_natural_no_zero']	= 'Natural, no zeroes';
 $lang['mb_form_valid_ip']		= 'Valid IP';
 $lang['mb_form_valid_base64']	= 'Valid Base64';
 $lang['mb_form_alpha_extra']	= 'AlphaNumerics, underscore, dash, periods and spaces.';
+$lang['mb_form_match_existing']	= 'Ensure this matches the existing fieldname!';
 
 // Activities
 $lang['mb_act_create']	= 'Module crée';

--- a/bonfire/modules/builder/language/persian/builder_lang.php
+++ b/bonfire/modules/builder/language/persian/builder_lang.php
@@ -119,6 +119,7 @@ $lang['mb_form_is_natural_no_zero']	= 'طبيعي بدون صفر';
 $lang['mb_form_valid_ip']		= 'IP معتبر';
 $lang['mb_form_valid_base64']	= 'Base64 معتبر';
 $lang['mb_form_alpha_extra']	= 'حروف الفبا, خط زير, خط تيره, نقطه و خط فاصله.';
+$lang['mb_form_match_existing']	= 'Ensure this matches the existing fieldname!';
 
 // Activities
 $lang['mb_act_create']	= 'ايجاد افزونه';

--- a/bonfire/modules/builder/language/portuguese_br/builder_lang.php
+++ b/bonfire/modules/builder/language/portuguese_br/builder_lang.php
@@ -119,6 +119,7 @@ $lang['mb_form_is_natural_no_zero'] = 'Natural, sem zeros';
 $lang['mb_form_valid_ip'] = 'Válido IP';
 $lang['mb_form_valid_base64'] = 'Base64 Válido';
 $lang['mb_form_alpha_extra'] = 'AlphaNuméricos, sublinhado, traço, períodos e espaços.';
+$lang['mb_form_match_existing']	= 'Ensure this matches the existing fieldname!';
 
 // Activities
 $lang['mb_act_create'] = 'Modulo Criado';

--- a/bonfire/modules/builder/language/spanish_am/builder_lang.php
+++ b/bonfire/modules/builder/language/spanish_am/builder_lang.php
@@ -122,6 +122,7 @@ $lang['mb_form_is_natural_no_zero']	= 'Natural, sin ceros';
 $lang['mb_form_valid_ip']		= 'IP válida';
 $lang['mb_form_valid_base64']	= 'Base64 válido';
 $lang['mb_form_alpha_extra']	= 'Alfanumerico, subrayado, guiones, periodos y espacios.';
+$lang['mb_form_match_existing']	= 'Ensure this matches the existing fieldname!';
 
 // Activities
 $lang['mb_act_create']	= 'Módulo creado';

--- a/bonfire/modules/builder/libraries/modulebuilder.php
+++ b/bonfire/modules/builder/libraries/modulebuilder.php
@@ -181,7 +181,7 @@ class Modulebuilder
 
             // db based files - migrations
             if( $db_required == 'new') {
-                $content['db_migration'] =  $this->build_db_sql($field_total, $module_name, $primary_key_field, $table_name, $table_as_field_prefix);
+                $content['db_migration'] = $this->build_db_sql($field_total, $module_name, $primary_key_field, $table_name, $table_as_field_prefix);
             }
         }
 
@@ -205,18 +205,18 @@ class Modulebuilder
         else {
             // write failed
             $data['error'] = TRUE;
-            $data['error_msg'] = $write_status['error'];
+            $data['error_msg'] 	= $write_status['error'];
         }
 
         // make the variables available to the view file
-        $data['acl_migration'] = $content['acl_migration'];
-        $data['build_config'] = $content['config'];
-        $data['controllers'] = $content['controllers'];
-        $data['db_migration'] = $content['db_migration'];
-        $data['lang'] = $content['lang'];
-        $data['model'] = $content['model'];
-        $data['views'] = $content['views'];
-        $data['db_table'] = $table_name;
+        $data['acl_migration'] 	= $content['acl_migration'];
+        $data['build_config'] 	= $content['config'];
+        $data['controllers'] 	= $content['controllers'];
+        $data['db_migration'] 	= $content['db_migration'];
+        $data['lang'] 			= $content['lang'];
+        $data['model'] 			= $content['model'];
+        $data['views'] 			= $content['views'];
+        $data['db_table'] 		= $table_name;
 
         return $data;
 
@@ -398,17 +398,17 @@ class Modulebuilder
               return FALSE;
         }
 
-        $data['field_total'] = $field_total;
-        $data['module_name'] = $module_name;
-        $data['module_name_lower'] = preg_replace("/[ -]/", "_", strtolower($module_name));
-        $data['controller_name'] = $controller_name;
-        $data['action_name'] = $action_name;
-        $data['primary_key_field'] = $primary_key_field;
-        $data['action_label'] = $action_label;
-        $data['textarea_editor'] = $this->CI->input->post('textarea_editor');
-        $data['use_soft_deletes'] = $this->CI->input->post('use_soft_deletes');
-        $data['use_created'] = $this->CI->input->post('use_created');
-        $data['use_modified'] = $this->CI->input->post('use_modified');
+        $data['field_total'] 		= $field_total;
+        $data['module_name'] 		= $module_name;
+        $data['module_name_lower'] 	= preg_replace("/[ -]/", "_", strtolower($module_name));
+        $data['controller_name'] 	= $controller_name;
+        $data['action_name'] 		= $action_name;
+        $data['primary_key_field'] 	= $primary_key_field;
+        $data['action_label'] 		= $action_label;
+        $data['textarea_editor'] 	= $this->CI->input->post('textarea_editor');
+        $data['use_soft_deletes'] 	= $this->CI->input->post('use_soft_deletes');
+        $data['use_created'] 		= $this->CI->input->post('use_created');
+        $data['use_modified'] 		= $this->CI->input->post('use_modified');
 
         $id_val = '';
         if($action_name != 'insert' && $action_name != 'add') {

--- a/bonfire/modules/builder/views/developer/modulebuilder_form.php
+++ b/bonfire/modules/builder/views/developer/modulebuilder_form.php
@@ -46,11 +46,7 @@ a.mb_show_advanced_rules:hover {
 <div class="admin-box">
 	<h3><?php echo $toolbar_title ?></h3>
 
-<?php if($field_total>0): ?>
-	<?php echo form_open(current_url().'/'.$field_total, array('id'=>"module_form",'class'=>"form-horizontal")); ?>
-<?php elseif($field_total==0): ?>
-	<?php echo form_open(current_url(), array('id'=>"module_form",'class'=>"form-horizontal")); ?>
-<?php endif; ?>
+<?php echo form_open(current_url().(($field_total>0)?('/'.$field_total):''), array('id'=>"module_form",'class'=>"form-horizontal")); ?>
 	<div>
 		<!-- Module Details -->
 		<fieldset id="module_details">
@@ -195,6 +191,7 @@ a.mb_show_advanced_rules:hover {
 						<option value="<?php echo $val?>"><?php echo $label?></option>
 						<?php endforeach;?>
 					</select>
+					<input type="hidden" name="soft_delete_field" id="soft_delete_field" value="deleted" />
 				</div>
 			</div>
 
@@ -213,6 +210,7 @@ a.mb_show_advanced_rules:hover {
 				<label for="created_field" class="control-label block"><?php echo lang('mb_form_created_field'); ?></label>
 				<div class="controls">
 					<input name="created_field" id="created_field" type="text" value="<?php echo set_value("created_field", "created_on"); ?>" />
+					<span class="help-inline match-existing-notes"><?php echo lang('mb_form_match_existing'); ?></span>
 					<span class="help-inline"><?php echo form_error('created_field'); ?></span>
 				</div>
 			</div>
@@ -232,6 +230,7 @@ a.mb_show_advanced_rules:hover {
 				<label for="modified_field" class="control-label block"><?php echo lang('mb_form_modified_field'); ?></label>
 				<div class="controls">
 					<input name="modified_field" id="modified_field" type="text" value="<?php echo set_value("modified_field", "modified_on"); ?>" />
+					<span class="help-inline match-existing-notes"><?php echo lang('mb_form_match_existing'); ?></span>
 					<span class="help-inline"><?php echo form_error('modified_field'); ?></span>
 				</div>
 			</div>

--- a/bonfire/modules/builder/views/files/db_migration.php
+++ b/bonfire/modules/builder/views/files/db_migration.php
@@ -98,8 +98,9 @@ class Migration_Install_'.$table_name.' extends Migration {
 	// use soft deletes? Add deleted field.
 	if ($this->input->post('use_soft_deletes') == 'true')
 	{
+		$delete_field = ($this->input->post('soft_delete_field')) ? $this->input->post('soft_delete_field') : 'deleted';
 		$db_migration .= "
-			'deleted' => array(
+			'".$delete_field."' => array(
 				'type' => 'TINYINT',
 				'constraint' => 1,
 				'default' => '0',

--- a/bonfire/modules/builder/views/files/view_index.php
+++ b/bonfire/modules/builder/views/files/view_index.php
@@ -60,20 +60,26 @@ for($counter=1; $field_total >= $counter; $counter++)
 	$headers .= '
 					<th>'. set_value("view_field_label$counter").'</th>';
 }
-if ($use_soft_deletes == 'true')
+
+// only add maintenance columns to view when module is creating a new db table
+// (columns should already be present and handled below when existing table is used)
+if($db_required == 'new')
 {
-	$headers .= '
-					<th>Deleted</th>';
-}
-if ($use_created == 'true')
-{
-	$headers .= '
-					<th>Created</th>';
-}
-if ($use_modified == 'true')
-{
-	$headers .= '
-					<th>Modified</th>';
+	if ($use_soft_deletes == 'true')
+	{
+		$headers .= '
+						<th>Deleted</th>';
+	}
+	if ($use_created == 'true')
+	{
+		$headers .= '
+						<th>Created</th>';
+	}
+	if ($use_modified == 'true')
+	{
+		$headers .= '
+						<th>Modified</th>';
+	}
 }
 
 $table_records = '';
@@ -82,7 +88,7 @@ for($counter=1; $field_total >= $counter; $counter++)
 {
 	// only build on fields that have data entered.
 
-	//Due to the requiredif rule if the first field is set the the others must be
+	//Due to the requiredif rule if the first field is set then the others must be
 
 	if (set_value("view_field_name$counter") == NULL || set_value("view_field_name$counter") == $primary_key_field)
 	{
@@ -112,30 +118,43 @@ for($counter=1; $field_total >= $counter; $counter++)
 			";
 	}
 	else {
-		$table_records .= '
-				<td><?php e($record->'.$field_name.') ?></td>';
+		// when building from existing table, modify output of the 'deleted' maintenance column
+		if  ($db_required == 'existing' && $field_name == $this->input->post("soft_delete_field"))
+		{
+			$table_records .= '
+					<td><?php echo $record->'.$field_name.' > 0 ? lang(\''.$module_name_lower.'_true\') : lang(\''.$module_name_lower.'_false\')?></td>';
+		}
+		else
+		{
+			$table_records .= '
+					<td><?php e($record->'.$field_name.') ?></td>';
+		}
 	}
 }
-if ($use_soft_deletes == 'true')
-{
-	$table_records .= '
-				<td><?php echo $record->deleted > 0 ? lang(\''.$module_name_lower.'_true\') : lang(\''.$module_name_lower.'_false\')?></td>';
-	$field_total++;
-}
-if ($use_created == 'true')
-{
-	$table_records .= '
-				<td><?php e($record->'.set_value("created_field").') ?></td>';
-	$field_total++;
-}
-if ($use_modified == 'true')
-{
-	$table_records .= '
-				<td><?php e($record->'.set_value("modified_field").') ?></td>';
-	$field_total++;
-}
 
-
+// only add maintenance columns to view when module is creating a new db table
+// (columns should already be present and handled above when existing table is used)
+if($db_required == 'new')
+{
+	if ($use_soft_deletes == 'true')
+	{
+		$table_records .= '
+					<td><?php echo $record->'.set_value("soft_delete_field").' > 0 ? lang(\''.$module_name_lower.'_true\') : lang(\''.$module_name_lower.'_false\')?></td>';
+		$field_total++;
+	}
+	if ($use_created == 'true')
+	{
+		$table_records .= '
+					<td><?php e($record->'.set_value("created_field").') ?></td>';
+		$field_total++;
+	}
+	if ($use_modified == 'true')
+	{
+		$table_records .= '
+					<td><?php e($record->'.set_value("modified_field").') ?></td>';
+		$field_total++;
+	}
+}
 
 $view = str_replace('{cols_total}', $field_total + 1 , $view);
 $view = str_replace('{table_header}', $headers, $view);


### PR DESCRIPTION
Module Builder

Bugfix when creating module from existing table
- MB would add View table columns for Deleted, Created, Modified when
  these would already have been displayed as part of the normal column
  names (from existing table)

Added
- Hidden form field containing name of 'deleted' column
  (for consistency with other fields and to remove hard-coded values)
- mb_form_match_existing entry in all builder_lang.php files
- display of mb_form_match_existing to modulebuilder_form.php
- show() and hide() of mb_form_match_existing to modulebuilder.js
