### PR TITLE
Port extended settings to 0.7

### DIFF
--- a/application/config/extended_settings.php
+++ b/application/config/extended_settings.php
@@ -1,0 +1,105 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+/**
+ * Bonfire
+ *
+ * An open source project to allow developers get a jumpstart their development of CodeIgniter applications
+ *
+ * @package   Bonfire
+ * @author    Bonfire Dev Team
+ * @copyright Copyright (c) 2013, Bonfire Dev Team
+ * @license   http://guides.cibonfire.com/license.html
+ * @link      http://cibonfire.com
+ * @since     Version 1.0
+ * @filesource
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * Extended Settings Fields Config
+ * The following examples show how to use regular inputs, select boxes,
+ * state and country select boxes.
+ * Note: the name field is limited to 26 characters
+ */
+$config['extended_settings_fields'] = array(
+	array(
+		'name'	=> 'extended_settings_test',
+		'label'	=> 'Test Label',
+		'rules'	=> 'trim|xss_clean',
+		'form_detail'	=> array(
+			'type'	=> 'dropdown',
+			'settings'	=> array(
+				'name'	=> 'extended_settings_test',
+				'id'	=> 'extended_settings_test',
+			),
+			'options'	=> array(
+				'0'	=> 'Passed',
+				'1'	=> 'Failed',
+			),
+		),
+		'permission' => 'This.Shouldnt.ShowUp',
+	),
+	array(
+		'name'   => 'street_name',
+		'label'   => lang('user_meta_street_name'),
+		'rules'   => 'trim|max_length[100]|xss_clean',
+		'form_detail' => array(
+			'type' => 'input',
+			'settings' => array(
+				'name'		=> 'street_name',
+				'id'		=> 'street_name',
+				'maxlength'	=> '100',
+				'class'		=> 'span6',
+			),
+		),
+		'permission' => 'Site.Settings.View',
+	),
+	array(
+		'name'   => 'state',
+		'label'   => lang('user_meta_state'),
+		'rules'   => 'required|trim|max_length[2]|xss_clean',
+		'form_detail' => array(
+			'type' => 'state_select',
+			'settings' => array(
+				'name'		=> 'state',
+				'id'		=> 'state',
+				'maxlength'	=> '2',
+				'class'		=> 'span1'
+			),
+		),
+		'permission' => 'Site.Content.View',
+	),
+	array(
+		'name'   => 'country',
+		'label'   => lang('user_meta_country'),
+		'rules'   => 'required|trim|max_length[100]|xss_clean',
+		'form_detail' => array(
+			'type' => 'country_select',
+			'settings' => array(
+				'name'		=> 'country',
+				'id'		=> 'country',
+				'maxlength'	=> '100',
+				'class'		=> 'span6'
+			),
+		),
+	),
+	array(
+		'name'   => 'type',
+		'label'   => lang('user_meta_type'),
+		'rules'   => 'required|xss_clean',
+		'form_detail' => array(
+			'type' => 'dropdown',
+			'settings' => array(
+				'name'		=> 'type',
+				'id'		=> 'type',
+				'class'		=> 'span6',
+			),
+			'options' =>  array(
+				'small'  => 'Small Shirt',
+				'med'    => 'Medium Shirt',
+				'large'   => 'Large Shirt',
+				'xlarge' => 'Extra Large Shirt',
+			  ),
+		),
+	),
+);

--- a/bonfire/modules/settings/controllers/settings.php
+++ b/bonfire/modules/settings/controllers/settings.php
@@ -64,9 +64,12 @@ class Settings extends Admin_Controller
 	 */
 	public function index()
 	{
+		$this->load->config('extended_settings');
+		$extended_settings = config_item('extended_settings_fields');
+
 		if ($this->input->post('save'))
 		{
-			if ($this->save_settings())
+			if ($this->save_settings($extended_settings))
 			{
 				Template::set_message(lang('settings_saved_success'), 'success');
 				redirect(SITE_AREA .'/settings');
@@ -80,6 +83,7 @@ class Settings extends Admin_Controller
 		// Read our current settings
 		$settings = $this->settings_lib->find_all();
 		Template::set('settings', $settings);
+		Template::set('extended_settings', $extended_settings);
 
 		// Get the possible languages
 		$this->load->helper('translate/languages');
@@ -102,11 +106,13 @@ class Settings extends Admin_Controller
 	/**
 	 * Performs the form validation and saves the settings to the database
 	 *
-	 * @access private
+	 * @access	private
 	 *
-	 * @return bool
+	 * @param	array	$extended_settings	An optional array of settings from the extended_settings config file
+	 *
+	 * @return	bool
 	 */
-	private function save_settings()
+	private function save_settings($extended_settings=array())
 	{
 		$this->form_validation->set_rules('title', 'lang:bf_site_name', 'required|trim');
 		$this->form_validation->set_rules('system_email', 'lang:bf_site_email', 'required|trim|valid_email');
@@ -117,6 +123,22 @@ class Settings extends Admin_Controller
 		$this->form_validation->set_rules('password_force_mixed_case', 'lang:bf_password_force_mixed_case', 'trim|numeric');
 		$this->form_validation->set_rules('password_show_labels', 'lang:bf_password_show_labels', 'trim|numeric');
 		$this->form_validation->set_rules('languages[]', 'lang:bf_language', 'required|trim|is_array');
+
+		$extended_data = array();
+		foreach ($extended_settings as $field)
+		{
+			if ( ! isset($field['permission'])
+				|| empty($field['permission'])
+				|| $field['permission'] === FALSE
+				|| isset($field['permission']) && ! empty($field['permission']) && has_permission($field['permission'])
+			)
+			{
+				$this->form_validation->set_rules($field['name'], $field['label'], $field['rules']);
+
+				$extended_data['ext.' . $field['name']] = $this->input->post($field['name']);
+			}
+
+		}
 
 		if ($this->form_validation->run() === FALSE)
 		{
@@ -166,9 +188,47 @@ class Settings extends Admin_Controller
 		// save the settings to the DB
 		$updated = $this->settings_model->update_batch($data, 'name');
 
+		// if the update was successful and we have extended settings to save,
+		if ($updated && ! empty($extended_data))
+		{
+			// go ahead and save them
+			$updated = $this->save_extended_settings($extended_data);
+		}
+
 		return $updated;
 
 	}//end save_settings()
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Save the extended settings
+	 *
+	 * @access	private
+	 *
+	 * @param	array	$extended_data	An array of settings to save
+	 *
+	 * @return	mixed/bool				TRUE or an inserted id if all settings saved successfully, else FALSE
+	 */
+	private function save_extended_settings($extended_data)
+	{
+		if ( ! is_array($extended_data) || empty($extended_data) || ! count($extended_data))
+		{
+			return FALSE;
+		}
+
+		$setting = FALSE;
+		foreach ($extended_data as $key => $value)
+		{
+			$setting = $this->settings_lib->set($key, $value);
+			if ($setting === FALSE)
+			{
+				return FALSE;
+			}
+		}
+
+		return $setting;
+	}
 
 	//--------------------------------------------------------------------
 }//end Settings()

--- a/bonfire/modules/settings/views/settings/index.php
+++ b/bonfire/modules/settings/views/settings/index.php
@@ -1,6 +1,6 @@
 <?php if (validation_errors()) : ?>
 <div class="alert alert-block alert-error fade in">
-  <a class="close" data-dismiss="alert">&times;</a>
+	<a class="close" data-dismiss="alert">&times;</a>
 	<?php echo validation_errors(); ?>
 </div>
 <?php endif; ?>
@@ -269,12 +269,82 @@
 				</div>
 				<!-- End of Developer Tab Options Pane -->
 			<?php endif; ?>
-		</div>
-	</div>
 
-	<div class="form-actions">
-		<input type="submit" name="save" class="btn btn-primary" value="<?php echo lang('bf_action_save') .' '. lang('bf_context_settings') ?>" />
-	</div>
+			<?php if ( ! empty($extended_settings)) : ?>
+				<!-- Start of Extended Settings Tab Pane -->
+				<div class='tab-pane' id='extended'>
+					<fieldset>
+						<legend>Extended</legend>
+			<?php
+				foreach ($extended_settings as $field)
+				{
+					if (isset($field['permission']) && ! empty($field['permission']) && has_permission($field['permission'])
+						|| ! isset($field['permission'])
+						|| empty($field['permission'])
+						|| $field['permission'] === FALSE
+					)
+					{
+						$form_error_class = form_error($field['name']) ? ' error' : '';
+						$field_control = '';
+
+						if ($field['form_detail']['type'] == 'dropdown')
+						{
+							echo form_dropdown($field['form_detail']['settings'], $field['form_detail']['options'], set_value($field['name'], isset($settings['ext.' . $field['name']]) ? $settings['ext.' . $field['name']] : ''), $field['label']);
+						}
+						elseif ($field['form_detail']['type'] == 'checkbox')
+						{
+							$field_control = form_checkbox($field['form_detail']['settings'], $field['form_detail']['value'], isset($settings['ext.' . $field['name']]) && $field['form_detail']['value'] == $settings['ext.' . $field['name']] ? TRUE : FALSE);
+						}
+						elseif ($field['form_detail']['type'] == 'state_select')
+						{
+							if ( ! is_callable('state_select'))
+							{
+								$this->load->config('address');
+								$this->load->helper('address');
+							}
+							$field_control = state_select(isset($settings['ext.' . $field['name']]) ? $settings['ext.' . $field['name']] : 'CA', 'CA', 'US', $field['name'], 'span6 chzn-select');
+						}
+						elseif ($field['form_detail']['type'] == 'country_select')
+						{
+							if ( ! is_callable('country_select'))
+							{
+								$this->load->config('address');
+								$this->load->helper('address');
+							}
+							$field_control = country_select(set_value($field['name'], isset($settings['ext.' . $field['name']]) ? $settings['ext.' . $field['name']] : 'US'), 'US', $field['name'], 'span6 chzn-select');
+						}
+						else
+						{
+							$form_method = 'form_' . $field['form_detail']['type'];
+							if (is_callable($form_method))
+							{
+								echo $form_method($field['form_detail']['settings'], set_value($field['name'], isset($settings['ext.' . $field['name']]) ? $settings['ext.' . $field['name']] : ''), $field['label']);
+							}
+						}
+
+						if ( ! empty($field_control))
+						{
+							echo "
+						<div class='control-group{$form_error_class}'>
+							<label class='control-label' for='{$field['name']}'>{$field['label']}</label>
+							<div class='controls'>
+								{$field_control}
+							</div>
+						</div>";
+						}
+					}
+				}
+			?>
+					</fieldset>
+				</div>
+			<?php endif; ?>
+
+			</div>
+		</div>
+
+		<div class="form-actions">
+			<input type="submit" name="save" class="btn btn-primary" value="<?php echo lang('bf_action_save') .' '. lang('bf_context_settings') ?>" />
+		</div>
 
 	<?php echo form_close(); ?>
-</div> <!-- /admin-box -->
+</div>


### PR DESCRIPTION
Adds an Extended Settings tab to the Site Settings page and creates the
fields from the extended_settings config file. See extended_settings.php
in the config directory for examples.
