### PR TITLE
Added timestamp to module js filename, Fixs issue #820

### DIFF
--- a/bonfire/libraries/assets.php
+++ b/bonfire/libraries/assets.php
@@ -886,7 +886,7 @@ class Assets
 		$src = self::combine_js($scripts, 'module');
 
 		$attr = array(
-			'src'	=> $src,
+			'src'	=> $src .'?_dt='.time(),
 			'type'	=> 'text/javascript',
 		);
 


### PR DESCRIPTION
After the module javascript files are combined, to prevent the browser from cache'in the module javascript which could be wrong if you use different java script for different methods.

Added simple timestamp to combined javascript file name 

``` php
   filename?_df=time()
```

Something like that. 
