### PR TITLE
Bugfix - Fixes apache filter_module.c inclusion

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -70,7 +70,7 @@
   </IfModule>
 
   # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-  <IfModule filter_module>
+  <IfModule filter_module.c>
     FilterDeclare   COMPRESS
     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
     FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css


### PR DESCRIPTION
For people cloning the repo, as opposed to downloading directly from cibonfire.com, the .htaccess file is corrupted due to the Apache filter_module inclusion being included improperly. I feel like this should definitely be added to the master branch of this project, but I'm fairly sure that it's repaired in the develop branch.
