### PR TITLE
fixes #903

### DIFF
--- a/application/controllers/images.php
+++ b/application/controllers/images.php
@@ -77,7 +77,7 @@ class Images extends Base_Controller {
 		$size	= $this->input->get('size');
 		$height	= $this->input->get('height');
 		$width	= $this->input->get('width');
-		$crop	= $this->input->get('crop');
+		$ratio	= $this->input->get('ratio');
 		$force	= $this->input->get('force');
 
 		$ext = pathinfo($file, PATHINFO_EXTENSION);
@@ -92,7 +92,7 @@ class Images extends Base_Controller {
 		{
 			$height = (int)$size;
 			$width	= (int)$size;
-			$crop 	= 'no';
+			$ratio 	= 'no';
 		}
 
 		// For now, simply return the file....
@@ -112,7 +112,7 @@ class Images extends Base_Controller {
 				'source_image'		=> $img_file,
 				'new_image'			=> $new_file,
 				'create_thumb'		=> false,
-				'maintain_ratio'	=> $crop == 'no' ? false : true,
+				'maintain_ratio'	=> $ratio == 'no' ? false : true,
 				'master_dim'		=> !empty($width) ? 'width' : 'height', 
 				'width'				=> !empty($width) ? $width : $height,
 				'height'			=> !empty($height) ? $height : $width,

--- a/bonfire/docs/working_with_assets.md
+++ b/bonfire/docs/working_with_assets.md
@@ -246,11 +246,15 @@ If you prefer to set a specific height and width, in pixels, for the image, you 
 
     <a href="http://mysite.com/images?height=60&width=100">My Thumbnail</a>
 
+You can also simply pass a <tt>width</tt> or <tt>height</tt> params to intelligently resize the image. Whichever param is passed will determine which is the "master" param. ex. If <tt>height</tt> is passed, the image will resize to a height of 60 and whatever width maintains aspect-ratio.
 
-By default, Bonfire will scale your image to fit within the new image size. To crop the image instead, pass along a <tt>crop=yes</tt> parameter.
+    <a href="http://mysite.com/images?height=60">
+    
+
+By default, Bonfire will scale your image to fit within the new image size. To resize the image and disregard aspect-ratio, pass along a <tt>ratio=no</tt> parameter.
 
 
-    <a href="http://mysite.com/images?size=80&crop=yes">My Thumbnail</a>
+    <a href="http://mysite.com/images?size=80&ratio=no">My Thumbnail</a>
 
 
 Bonfire will look for the images within the <tt>assets/images</tt> folder in your web root. If you need to pull files from a different folder, you can use the <tt>assets</tt> parameter and pass in a folder relative to the webroot.


### PR DESCRIPTION
changes default behavior of images controller
by default
maintains ratio
allows smart resize and maintains square image

I figured that most of the time aspect ratio of an image would more often than not be preferred, and the addition of smart-resizing auto-magically would be great.
You can leave out the width/height and it works without the auto and crop=yes.
