### PR TITLE
Update users.php

### DIFF
--- a/bonfire/modules/users/controllers/users.php
+++ b/bonfire/modules/users/controllers/users.php
@@ -258,7 +258,8 @@ class Users extends Front_Controller
 					if ((!isset($field['admin_only']) || $field['admin_only'] === FALSE
 						|| (isset($field['admin_only']) && $field['admin_only'] === TRUE
 							&& isset($this->current_user) && $this->current_user->role_id == 1))
-						&& (!isset($field['frontend']) || $field['frontend'] === TRUE))
+						&& (!isset($field['frontend']) || $field['frontend'] === TRUE)
+						&& $this->input->post($field['name']) !== FALSE)
 					{
 						$meta_data[$field['name']] = $this->input->post($field['name']);
 					}


### PR DESCRIPTION
ADD field POST value check in function profile()
This will be very handful if there is a few account types (for example, free/pro types). And in "pro"-account we have a couple of extra fields. If account was degraded to "free" and user edits his profile (there's no extra-fields in update form now) - this extra fields will taken a value of '0', but we want to keep it's previous value for the case of future account upgrade to "pro".
This check will fix it.
And... yeah, sorry for my bad English.
