### PR TITLE
Fixed Installer trying to set iterations for user (Column Removed)

### DIFF
--- a/bonfire/libraries/installer_lib.php
+++ b/bonfire/libraries/installer_lib.php
@@ -493,7 +493,6 @@ class Installer_lib {
 		$password = $hasher->HashPassword('password');
 
 		$data['password_hash'] = $password;
-		$data['password_iterations'] = $iterations;
 		$data['created_on'] = date('Y-m-d H:i:s');
 		$data['display_name'] = $data['username'];
 


### PR DESCRIPTION
`bonfire/libraries/installer_lib.php`

Line 496: `$data['password_iterations'] = $iterations;`

Tries to add iterations to the users table, which can't happen since the column has been removed. Just created a Pull Request to fix it.

Fixed.
