### PR TITLE
Only display keyboard shortcuts settings link for users with the right to change them

### DIFF
--- a/public/themes/admin/header.php
+++ b/public/themes/admin/header.php
@@ -61,7 +61,9 @@ if (isset($shortcut_data) && is_array($shortcut_data['shortcut_keys'])) {
                                         <li><span><?php e($data); ?></span> : <?php echo $shortcut_data['shortcuts'][$key]['description']; ?></li>
                                         <?php endforeach; ?>
                                     </ul>
+				    <?php if ( has_permission('Bonfire.UI.View') && has_permission('Bonfire.UI.Manage') ): ?>
                                     <a href="<?php echo site_url(SITE_AREA . '/settings/ui'); ?>"><?php echo lang('bf_keyboard_shortcuts_edit'); ?></a>
+				    <?php endif; ?>
                                 </div>
                             </li>
 						</ul>


### PR DESCRIPTION
Right now, it is displayed to anyone who has access to the admin area, regardless of the permissions the user has to actually change these settings.

(The trailing newline was automatically added by VIM, it appears.)
