### PR TITLE
Update Migrations.php to fix installer duplicate key bug

### DIFF
--- a/bonfire/modules/migrations/libraries/Migrations.php
+++ b/bonfire/modules/migrations/libraries/Migrations.php
@@ -934,7 +934,8 @@ class Migrations
             }
 
             // When moving to a version other than 0...
-            if (empty($currentVersion)) {
+            // if (empty($currentVersion)) { // Fixed logical condition test error where 0 was equal to "empty" - By CorkyKaericher 05/25/2014
+            if($currentVersion !== '0'){
                 // If the version was not found, insert it
                 $result = $this->_ci->db->insert(
                     $this->migrationsTable,


### PR DESCRIPTION
Fixing logical error in conditional on line 945 where trying to check if var $currentVersion is "empty()" when that version is set to zero (0) to check if $currentVersion is !== '0' instead. PHP empty() function would consider zero to be false, and thus empty and then the subsequent SQL is applied incorrectly as a result. This patch resolves that issue and allows the installer to proceed properly now.

This will also fix/resolve issue #1035 which is about the same error I have fixed here.
