### PR TITLE
Automatically focus the e-mail/username field on the login page

### DIFF
--- a/bonfire/modules/users/views/login.php
+++ b/bonfire/modules/users/views/login.php
@@ -25,7 +25,8 @@
 
 		<div class="control-group <?php echo iif( form_error('login') , 'error') ;?>">
 			<div class="controls">
-				<input style="width: 95%" type="text" name="login" id="login_value" value="<?php echo set_value('login'); ?>" tabindex="1" placeholder="<?php echo $this->settings_lib->item('auth.login_type') == 'both' ? lang('bf_username') .'/'. lang('bf_email') : ucwords($this->settings_lib->item('auth.login_type')) ?>" />
+				<input style="width: 95%" autofocus type="text" name="login" id="login_value" value="<?php echo set_value('login'); ?>" tabindex="1" placeholder="<?php echo $this->settings_lib->item('auth.login_type') == 'both' ? lang('bf_username') .'/'. lang('bf_email') : ucwords($this->settings_lib->item('auth.login_type')) ?>" />
+				<script type="text/javascript">document.getElementById('login_value').focus()</script>
 			</div>
 		</div>
 


### PR DESCRIPTION
So that a user doesn't have to tab to / click on the login field every time.

The script block directly after the input is as a fall-back for browsers that don't support  the `autofocus` attribute. Its placement inside of the document is intentional, to ensure that the input is focused as soon as it appears, to allow the user to start typing faster and to prevent the user tabbing away or clicking somewhere else before the input is focused.
