### PR TITLE
Fixed required fields generation in module creation

### DIFF
--- a/bonfire/modules/builder/views/files/view_default.php
+++ b/bonfire/modules/builder/views/files/view_default.php
@@ -54,11 +54,11 @@ for ($counter = 1; $field_total >= $counter; $counter++) {
 				<?php echo form_label('{$field_label}'{$required}, '', array('class' => 'control-label', 'id' => '{$form_name}_label')); ?>
 				<div class='controls' aria-labelled-by='{$form_name}_label'>
 					<label class='radio' for='{$form_name}_option1'>
-						<input id='{$form_name}_option1' name='{$form_name}' type='radio' ".($required_attribute?", 'required ' => ''":"")."class='' value='option1' <?php echo set_radio('{$form_name}', 'option1', isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 'option1'); ?> />
+						<input id='{$form_name}_option1' name='{$form_name}' type='radio' ".($required_attribute?"require":"")."class='' value='option1' <?php echo set_radio('{$form_name}', 'option1', isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 'option1'); ?> />
 						Radio option 1
 					</label>
 					<label class='radio' for='{$form_name}_option2'>
-						<input id='{$form_name}_option2' name='{$form_name}' type='radio'".($required_attribute?", ' required' => ''":"")." class='' value='option2' <?php echo set_radio('{$form_name}', 'option2', isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 'option2'); ?> />
+						<input id='{$form_name}_option2' name='{$form_name}' type='radio'".($required_attribute?"require":"")." class='' value='option2' <?php echo set_radio('{$form_name}', 'option2', isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 'option2'); ?> />
 						Radio option 2
 					</label>
 					<span class='help-inline'><?php echo form_error('{$field_name}'); ?></span>
@@ -90,7 +90,7 @@ for ($counter = 1; $field_total >= $counter; $counter++) {
 			<div class=\"control-group<?php echo form_error('{$field_name}') ? ' error' : ''; ?>\">
 				<div class='controls'>
 					<label class='checkbox' for='{$form_name}'>
-						<input type='checkbox' id='{$form_name}' name='{$form_name}'".($required_attribute?", ' required' => ''":"")." value='1' <?php echo set_checkbox('{$form_name}', 1, isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 1); ?> />
+						<input type='checkbox' id='{$form_name}' name='{$form_name}'".($required_attribute?"require":"")." value='1' <?php echo set_checkbox('{$form_name}', 1, isset(\${$module_name_lower}->{$field_name}) && \${$module_name_lower}->{$field_name} == 1); ?> />
                         '{$field_label}'{$required}
 					</label>
                     <span class='help-inline'><?php echo form_error('{$field_name}'); ?></span>
@@ -125,7 +125,7 @@ for ($counter = 1; $field_total >= $counter; $counter++) {
 			<div class=\"control-group<?php echo form_error('{$field_name}') ? ' error' : ''; ?>\">
 				<?php echo form_label('{$field_label}'{$required}, '{$form_name}', array('class' => 'control-label')); ?>
 				<div class='controls'>
-					<input id='{$form_name}' type='{$type}'".($required_attribute?", ' required' => ''":"")." name='{$form_name}' {$maxlength} value=\"<?php echo set_value('{$form_name}', isset(\${$module_name_lower}->{$field_name}) ? \${$module_name_lower}->{$field_name} : ''); ?>\" />
+					<input id='{$form_name}' type='{$type}'".($required_attribute?"require":"")." name='{$form_name}' {$maxlength} value=\"<?php echo set_value('{$form_name}', isset(\${$module_name_lower}->{$field_name}) ? \${$module_name_lower}->{$field_name} : ''); ?>\" />
 					<span class='help-inline'><?php echo form_error('{$field_name}'); ?></span>
 				</div>
 			</div>";


### PR DESCRIPTION
Had problem while generating modules. HTML tags were displaying information outside there bounds. Have no idea, why it were done the way it was, but hopefully my fix is correct.
