### PR TITLE
logout log_activity cannot be executed

### DIFF
--- a/bonfire/modules/users/controllers/Users.php
+++ b/bonfire/modules/users/controllers/Users.php
@@ -43,6 +43,7 @@ class Users extends Front_Controller
         $this->load->model('users/user_model');
 
         $this->load->library('users/auth');
+        $this->set_current_user();
 
         $this->lang->load('users');
         $this->siteSettings = $this->settings_lib->find_all();


### PR DESCRIPTION
since in the constructor, we do not set current user. when logout, the $this->current_user is NULL and log_activity will never be executed.