### PR TITLE
Fixed /public/tests.php not running successfully due to backslash

### DIFF
--- a/tests/run.php
+++ b/tests/run.php
@@ -341,6 +341,9 @@ function discover_tests($start_folder=null, $ignore_onlys=false)
 	{
 		foreach ($folders as $folder)
 		{
+			// remove trailing backslash
+			$folder = str_replace("\\", "", $folder);
+
 			// Folders get ran back through this function
 			// and will return an array of valid files.
 			// Merge this array with ours and call it good.


### PR DESCRIPTION
Fixed /public/tests.php not running successfully due to backslash. Problem was instead of showing "Bonfire Test", it shows "SimpleTest documentation".