### PR TITLE
Fixed wrong date displayed due to un-utilized user timezone. Updated system_events docs with undocumented system events.

### DIFF
--- a/bonfire/docs/changelog.md
+++ b/bonfire/docs/changelog.md
@@ -12,6 +12,8 @@
 
 #### Closes Issues:
 * #1163/1164: Fix /public/tests.php shows "SimpleTest documentation" instead of "Bonfire Tests".
+* #1165: Fixed failed tests and updated root index.php
+* #1166: Fixed wrong date displayed due to un-utilized user timezone.
 
 #### Additional Changes:
 

--- a/bonfire/docs/system_events.md
+++ b/bonfire/docs/system_events.md
@@ -59,6 +59,8 @@ Event	 | Description
 ---------------------------------|-------------
 before_controller	 | Called prior to the controller constructor being ran. Payload is the name of the current controller.	|
 after_controller_constructor	| Called just after the controller constructor is ran, but prior to the method being ran. Payload is the name of the current controller.	|
+before_front_controller | Called prior to the Front Controller constructor being ran. No Payload.
+after_front_controller | Called just after the Front Controller constructor being ran. No Payload.
 
 **Templates and Pages**
 
@@ -72,11 +74,15 @@ after_block_render	 | Called just after the block is rendered. Payload is an arr
 
 Event	 | Description
 -----------------------------|---------------
+purge_user | Called after a user is purged(hard-deleted from db). Payload is user's id. |
+before_user_validation | Called on saving a user from either `insert` or `update` before running form validation. Payload is an array of `user_id` and POST `data`|
 after_login	 | Called after successful login. Payload is an array of `user_id` and `role_id`.	|
 before_logout	 | Called just before logging the user out. Payload is an array of `user_id` and `role_id`.	|
 after_create_user	 | Called after a user is created. Payload is the new user’s id.	|
 before_user_update	 | Called just prior to updating a user. Payload is an array of `user_id` and ‘data’, where data is all of the update information passed into the method. Note: `user_id` may be an array if the `user_model`'s `update()` method is called with an array as the first parameter. In this case, the user's ID may not be in the array...	|
 after_user_update	 | Called just after updating a user. Payload is an array of `user_id` and ‘data’, where data is all of the update information passed into the method. Note: `user_id` may be an array if the `user_model`'s `update()` method is called with an array as the first parameter. In this case, the user's ID may not be in the array...	|
+save_user | Called after a user is inserted or updated and meta data is saved. Payload is an array of `user_id`, `result` of insert and update, and POST `data`. Note: `result` from insert is boolean|integer The ID of the new user on success, else false. `result` from update is boolean True if the update succeeded, null on invalid $id, or false on failure. |
+render_user_form     | Called on user form views before rendering user_meta fields. This allow modules to render custom fields. Payload is `null` on registration and user data on profile or updating user. 
 
 ## Using Events In Your Modules
 

--- a/bonfire/docs/upgrade/084.md
+++ b/bonfire/docs/upgrade/084.md
@@ -27,3 +27,16 @@
 * Update `/bonfire/ci3/libraries/Pagination.php`
 
 * Update `/tests/run.php`
+
+* Update `/index.php`
+* Update `/tests/_support/database.php`
+* Update `/tests/bonfire/helpers/address_helpers_test.php`
+* Update `/tests/bonfire/libraries/assets_test.php`
+* Update `/tests/bonfire/core/MY_Model_test.php`
+
+* Update `bonfire/modules/activities/controllers/Reports.php`
+* Update `bonfire/modules/activities/views/reports/view.php`
+* Update `bonfire/modules/emailer/controllers/Settings.php`
+* Update `bonfire/modules/emailer/views/settings/create.php`
+* Update `bonfire/modules/users/controllers/Settings.php`
+* Update `bonfire/modules/users/views/settings/index.php`

--- a/bonfire/modules/activities/controllers/Reports.php
+++ b/bonfire/modules/activities/controllers/Reports.php
@@ -59,6 +59,8 @@ class Reports extends Admin_Controller
 
         $this->load->model('activities/activity_model');
 
+        $this->load->helper('date_helper');
+
         Assets::add_js(
             array(
                 'bootstrap',
@@ -358,11 +360,12 @@ class Reports extends Admin_Controller
                 break;
             case 'activity_date':
                 foreach ($this->activity_model->find_all_by($activityDeletedField, 0) as $e) {
-                    $options[$e->activity_id] = $e->created_on;
+                    $options[$e->activity_id] = user_time(strtotime($e->created_on), null);
                     if ($filterValue == $e->activity_id) {
                         $name = $e->created_on;
                     }
                 }
+
                 $where = 'activity_id';
                 Template::set('hasPermissionDeleteDate', $this->auth->has_permission($this->permissionDeleteDate));
                 break;

--- a/bonfire/modules/activities/views/reports/view.php
+++ b/bonfire/modules/activities/views/reports/view.php
@@ -73,7 +73,7 @@ $hasPermissionDeleteUser   = isset($hasPermissionDeleteUser) ? $hasPermissionDel
                 <td><span class="icon-user"></span>&nbsp;<?php e($activity->username); ?></td>
                 <td><?php echo $activity->activity; ?></td>
                 <td><?php echo $activity->module; ?></td>
-                <td><?php echo date('M j, Y g:i A', strtotime($activity->created)); ?></td>
+                <td><?php echo user_time(strtotime($activity->created), null, 'M j, Y g:i A'); ?></td>
             </tr>
             <?php endforeach; ?>
         </tbody>

--- a/bonfire/modules/emailer/controllers/Settings.php
+++ b/bonfire/modules/emailer/controllers/Settings.php
@@ -264,6 +264,7 @@ class Settings extends Admin_Controller
      */
     public function create()
     {
+        $this->load->helper('date_helper');
         $this->load->model('users/user_model');
 
         if (isset($_POST['create'])) {

--- a/bonfire/modules/emailer/views/settings/create.php
+++ b/bonfire/modules/emailer/views/settings/create.php
@@ -70,7 +70,7 @@
                     </td>
                     <td><?php echo $user->display_name; ?></td>
                     <td><?php echo empty($user->email) ? '' : mailto($user->email); ?></td>
-                    <td><?php echo $user->last_login == '0000-00-00 00:00:00' ? '---' : date('M j, y g:i A', strtotime($user->last_login)); ?></td>
+                    <td><?php echo $user->last_login == '0000-00-00 00:00:00' ? '---' : user_time(strtotime($user->last_login), null, 'M j, y g:i A'); ?></td>
                     <td><?php if ($user->active) : ?>
                         <span class="label label-success"><?php echo lang('us_active'); ?></span>
                         <?php else : ?>

--- a/bonfire/modules/users/controllers/Settings.php
+++ b/bonfire/modules/users/controllers/Settings.php
@@ -65,6 +65,8 @@ class Settings extends Admin_Controller
      */
     public function index($filter = 'all', $offset = 0)
     {
+        $this->load->helper('date_helper');
+
         $this->auth->restrict($this->permissionManage);
 
         // Fetch roles for the filter and the list.

--- a/bonfire/modules/users/controllers/Settings.php
+++ b/bonfire/modules/users/controllers/Settings.php
@@ -540,9 +540,10 @@ class Settings extends Admin_Controller
             $this->user_model->save_meta_for($id, $metaData);
         }
 
+        // Add result to payload.
+        $payload['result'] = $result;
         // Any modules needing to save data?
-        $postData = $this->input->post();
-        Events::trigger('save_user', $postData);
+        Events::trigger('save_user', $payload);
 
         return $result;
     }

--- a/bonfire/modules/users/controllers/Users.php
+++ b/bonfire/modules/users/controllers/Users.php
@@ -607,6 +607,8 @@ class Users extends Front_Controller
             $this->user_model->save_meta_for($id, $metaData);
         }
 
+        // Add result to payload.
+        $payload['result'] = $result;
         // Trigger event after saving the user.
         Events::trigger('save_user', $payload);
 

--- a/bonfire/modules/users/views/settings/index.php
+++ b/bonfire/modules/users/views/settings/index.php
@@ -101,7 +101,7 @@ else :
 				<td><?php echo $user->display_name; ?></td>
 				<td><?php echo $user->email ? mailto($user->email) : ''; ?></td>
 				<td><?php echo $roles[$user->role_id]->role_name; ?></td>
-				<td class='last-login'><?php echo $user->last_login != '0000-00-00 00:00:00' ? date('M j, y g:i A', strtotime($user->last_login)) : '---'; ?></td>
+				<td class='last-login'><?php echo $user->last_login != '0000-00-00 00:00:00' ? user_time(strtotime($user->last_login), null, 'M j, y g:i A') : '---'; ?></td>
 				<td class='status'>
 					<?php if ($user->active) : ?>
 					<span class="label label-success"><?php echo lang('us_active'); ?></span>


### PR DESCRIPTION
Problem: 
* activities 'Performed' column is not displaying on local time.
* users 'last_login' column is not displaying on local time.
* emailer send emails 'last_login' column is not displaying on local time.

At first I thought the Model is saving the wrong time.

Solution: Utilize user-set timezone.