### PR TITLE
Update config_file_helper.php

### DIFF
--- a/bonfire/helpers/config_file_helper.php
+++ b/bonfire/helpers/config_file_helper.php
@@ -261,7 +261,23 @@ if (! function_exists('write_config')) {
                 $found = true;
             }
         }
-
+        
+        // Look for in environment
+        if (! $found)  {
+            $checkLocations = array();
+            if (defined('ENVIRONMENT')) {
+                $checkLocations[] = APPPATH . 'config/' . ENVIRONMENT . "/{$file}";
+            }
+            $checkLocations[] = APPPATH . "config/{$file}";
+            foreach ($checkLocations as $location) {
+                if (file_exists($location . '.php')) {
+                    $configFile = $location;
+                    $found = true;
+                    break;
+                }
+            }
+        }
+        
         // Fall back to application directory.
         if (! $found) {
             $configFile = "{$apppath}{$configFile}";


### PR DESCRIPTION
in this helper class, the function ` read_config()` read config files from environment path, but the function `write_config()` not do this, so it can not work good for that who use multiple environments.
I fix this for by following the logic of function `read_config()`.