### PR TITLE
Fix bug: requires password enter when update my profile

### DIFF
--- a/bonfire/modules/users/models/User_model.php
+++ b/bonfire/modules/users/models/User_model.php
@@ -51,7 +51,7 @@ class User_model extends BF_Model
         [
             'field' => 'password',
             'label' => 'lang:bf_password',
-            'rules' => 'max_length[120]|valid_password|matches[pass_confirm]',
+            'rules' => 'max_length[120]|valid_password',
         ],
         [
             'field' => 'pass_confirm',


### PR DESCRIPTION
When update profile, system requires user enter the password (can't left it empty). This patch to fix this bug